### PR TITLE
Improve logging for conditions / and handling of validation errors

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -7,6 +7,7 @@ use base qw( Workflow::Base Class::Observable );
 use Log::Log4perl qw( get_logger );
 use Workflow::Context;
 use Workflow::Exception qw( workflow_error );
+use Exception::Class;
 use Workflow::Factory qw( FACTORY );
 use Carp qw(croak carp);
 use English qw( -no_match_vars );
@@ -120,6 +121,12 @@ sub execute_action {
         $self->state($old_state);
 
         $self->_factory()->_rollback_transaction($self);
+
+        # If it is a validation error we rethrow it so it can be evaluated
+        # by the caller to provide better feedback to the user
+        if (Exception::Class->caught('Workflow::Exception::Validation')) {
+            $EVAL_ERROR->rethrow();
+        }
 
         # Don't use 'workflow_error' here since $error should already
         # be a Workflow::Exception object or subclass

--- a/lib/Workflow/Exception.pm
+++ b/lib/Workflow/Exception.pm
@@ -50,8 +50,13 @@ sub _mythrow {
     my $log = get_logger();
     my ( $pkg, $line ) = (caller)[ 0, 2 ];
     my ( $prev_pkg, $prev_line ) = ( caller 1 )[ 0, 2 ];
-    $log->error( "$type exception thrown from [$pkg: $line; before: ",
-        "$prev_pkg: $prev_line]: $msg" );
+
+    # Do not log condition errors
+    if ($type ne 'condition_exception') {
+        $log->error( "$type exception thrown from [$pkg: $line; before: ",
+            "$prev_pkg: $prev_line]: $msg" );
+    }
+
     goto &Exception::Class::Base::throw(
         $TYPE_CLASSES{$type},
         message => $msg,

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -8,6 +8,7 @@ use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
 use Workflow::Condition::Evaluate;
 use Workflow::Exception qw( workflow_error );
+use Exception::Class;
 use Workflow::Factory qw( FACTORY );
 use English qw( -no_match_vars );
 
@@ -69,7 +70,15 @@ sub get_available_action_names {
 sub is_action_available {
     my ( $self, $wf, $action_name ) = @_;
     eval { $self->evaluate_action( $wf, $action_name ) };
-    return ( !$EVAL_ERROR );
+
+    # Everything is fine
+    return 1 unless( $EVAL_ERROR );
+
+    # We got an exception, check if it is a Workflow::Exception
+    return 0 if (Exception::Class->caught('Workflow::Exception'));
+
+    $EVAL_ERROR->rethrow();
+
 }
 
 sub clear_condition_cache {
@@ -172,15 +181,31 @@ sub evaluate_action {
             eval { $condition->evaluate($wf) };
             if ($EVAL_ERROR) {
 
-                # TODO: We may just want to pass the error up
-                # without wrapping it...
-                $self->{'_condition_result_cache'}->{$orig_condition} = 0;
-                if ( !$opposite ) {
-                    workflow_error "No access to action '$action_name' in ",
-                        "state '$state' because: $EVAL_ERROR";
+                # Check if this is a Workflow::Exception::Condition
+                if (Exception::Class->caught('Workflow::Exception::Condition')) {
+                    # TODO: We may just want to pass the error up
+                    # without wrapping it...
+                    $self->{'_condition_result_cache'}->{$orig_condition} = 0;
+                    if ( !$opposite ) {
+                        workflow_error "No access to action '$action_name' in ",
+                            "state '$state' because: $EVAL_ERROR";
+                    } else {
+                        $log->is_debug
+                            && $log->debug("Opposite and condition failed with $EVAL_ERROR)");
+                    }
                 } else {
                     $log->is_debug
-                        && $log->debug("Opposite and condition failed");
+                            && $log->debug("Got uncatchable exception in condition $condition_name ");
+
+                    # if EVAL_ERROR is an execption object rethrow it
+                    $EVAL_ERROR->rethrow() if (ref $EVAL_ERROR ne'');
+
+                    # if it is a string (bubbled up from die/croak), make an Exception Object
+                    # For briefness, we just send back the first line of EVAL
+                    my @t = split /\n/, $EVAL_ERROR;
+                    my $ee = shift @t;
+                    Exception::Class::Base->throw( error
+                        => "Got unknown exception while handling condition '$condition_name' / " . $ee );
                 }
             } else {
                 $self->{'_condition_result_cache'}->{$orig_condition} = 1;

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -187,15 +187,19 @@ sub evaluate_action {
                     # without wrapping it...
                     $self->{'_condition_result_cache'}->{$orig_condition} = 0;
                     if ( !$opposite ) {
+                        $log->is_debug
+                            && $log->debug("No access to action '$action_name', condition " .
+                             "'$orig_condition' failed because ' . $EVAL_ERROR");
+
                         workflow_error "No access to action '$action_name' in ",
                             "state '$state' because: $EVAL_ERROR";
                     } else {
                         $log->is_debug
-                            && $log->debug("Opposite and condition failed with $EVAL_ERROR)");
+                            && $log->debug("opposite condition '$orig_condition' failed because ' . $EVAL_ERROR");
                     }
                 } else {
                     $log->is_debug
-                            && $log->debug("Got uncatchable exception in condition $condition_name ");
+                        && $log->debug("Got uncatchable exception in condition $condition_name ");
 
                     # if EVAL_ERROR is an execption object rethrow it
                     $EVAL_ERROR->rethrow() if (ref $EVAL_ERROR ne'');
@@ -210,13 +214,23 @@ sub evaluate_action {
             } else {
                 $self->{'_condition_result_cache'}->{$orig_condition} = 1;
                 if ($opposite) {
+
+                    $log->is_debug
+                        && $log->debug(
+                            "No access to action '$action_name', condition '$orig_condition' ".
+                            "did NOT failed but opposite requested");
+
                     workflow_error "No access to action '$action_name' in ",
                         "state '$state' because condition ",
                         "$orig_condition did NOT fail and we ",
                         "are checking $condition_name.";
                 } else {
-                    $log->is_debug
-                        && $log->debug(" Opposite false and condition OK");
+
+                    $log->is_debug &&
+                        $log->debug(
+                            "condition '$orig_condition' failed, because '$EVAL_ERROR', " .
+                            "but opposite requested");
+
                 }
             }
         }

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -77,7 +77,9 @@ sub is_action_available {
     # We got an exception, check if it is a Workflow::Exception
     return 0 if (Exception::Class->caught('Workflow::Exception'));
 
-    $EVAL_ERROR->rethrow();
+    $EVAL_ERROR->rethrow() if (ref $EVAL_ERROR);
+
+    croak $EVAL_ERROR;
 
 }
 


### PR DESCRIPTION
Those patches change the way how false conditions and validation errors are handled.

As conditions are realised via exceptions, a false condition appears with log level error in log4perl which is anoying as a false condition is a very normal situation in a workflow that has different branches. This patch surpresses those errors and logs the decissions made in a more constiant way using log->debug.

In addition, real exceptions that occur in custom validation/condition classes now bubble up so you can see the real exception in your application.