### PR TITLE
Fix/Additional improvements on condition error logging

### DIFF
--- a/lib/Workflow/Exception.pm
+++ b/lib/Workflow/Exception.pm
@@ -50,7 +50,7 @@ sub _mythrow {
     my ( $prev_pkg, $prev_line ) = ( caller 1 )[ 0, 2 ];
 
     # Do not log condition errors
-    if ($type ne 'condition_exception') {
+    if ($type ne 'condition_error') {
         $log->error( "$type exception thrown from [$pkg: $line; before: ",
             "$prev_pkg: $prev_line]: $msg" );
     }

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -5,7 +5,7 @@ use strict;
 use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
 use Workflow::Condition::Evaluate;
-use Workflow::Exception qw( workflow_error );
+use Workflow::Exception qw( workflow_error condition_error );
 use Exception::Class;
 use Workflow::Factory qw( FACTORY );
 use English qw( -no_match_vars );
@@ -141,7 +141,7 @@ sub evaluate_action {
                 {
                     $log->is_debug
                         && $log->debug("Cached condition result is false.");
-                    workflow_error "No access to action '$action_name' in ",
+                    condition_error "No access to action '$action_name' in ",
                         "state '$state' because cached ",
                         "condition '$orig_condition' already ",
                         "failed before.";
@@ -155,7 +155,7 @@ sub evaluate_action {
                 if ( $self->{'_condition_result_cache'}->{$orig_condition} ) {
                     $log->is_debug
                         && $log->debug("Cached condition is true.");
-                    workflow_error "No access to action '$action_name' in ",
+                    condition_error "No access to action '$action_name' in ",
                         "state '$state' because cached ",
                         "condition '$orig_condition' did NOT ",
                         "fail before and we are being asked ",
@@ -191,7 +191,7 @@ sub evaluate_action {
                             && $log->debug("No access to action '$action_name', condition " .
                              "'$orig_condition' failed because ' . $EVAL_ERROR");
 
-                        workflow_error "No access to action '$action_name' in ",
+                        condition_error "No access to action '$action_name' in ",
                             "state '$state' because: $EVAL_ERROR";
                     } else {
                         $log->is_debug
@@ -220,7 +220,7 @@ sub evaluate_action {
                             "No access to action '$action_name', condition '$orig_condition' ".
                             "did NOT failed but opposite requested");
 
-                    workflow_error "No access to action '$action_name' in ",
+                    condition_error "No access to action '$action_name' in ",
                         "state '$state' because condition ",
                         "$orig_condition did NOT fail and we ",
                         "are checking $condition_name.";


### PR DESCRIPTION
Those commits prevent the results of the condition evaluation to be logged as error by the upper layer.