### PR TITLE
Fix too greedy join in HasRequiredField Validator

### DIFF
--- a/lib/Workflow/Validator/HasRequiredField.pm
+++ b/lib/Workflow/Validator/HasRequiredField.pm
@@ -17,8 +17,8 @@ sub validate {
         }
     }
     if ( scalar @no_value ) {
-        validation_error "The following fields require a value: ", join ', ',
-            @no_value, { invalid_fields => \@no_value };
+        validation_error "The following fields require a value: ",
+            join(', ',@no_value), { invalid_fields => \@no_value };
     }
 }
 


### PR DESCRIPTION
# Description

join in HasRequiredFields validator is too greedy and merges the contents of the hash as "HASH(...)" into the stringyfied error message. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
