### PR TITLE
Cause side effects in cached condition tests without time()

### DIFF
--- a/t/TestCachedApp/Condition/EvenCounts.pm
+++ b/t/TestCachedApp/Condition/EvenCounts.pm
@@ -1,4 +1,4 @@
-package TestCachedApp::Condition::EvenSeconds;
+package TestCachedApp::Condition::EvenCounts;
 
 # $Id$
 
@@ -6,11 +6,12 @@ use strict;
 use base qw( Workflow::Condition );
 use Workflow::Exception qw( condition_error );
 
+my $count = 0;
+
 sub evaluate {
     my ( $self, $wf ) = @_;
-    sleep 1;
-    if (time() % 2 == 1) {
-        condition_error "Current seconds are not divisible by 2";
+    if ($count++ % 2 == 1) {
+        condition_error "Current count is not divisible by 2";
     }
 }
 

--- a/t/workflow_cached_condition.xml
+++ b/t/workflow_cached_condition.xml
@@ -4,10 +4,10 @@
  <persister>TestPersister</persister>
  <state name="INITIAL">
      <action name="TEST" resulting_state="INITIAL">
-         <condition name="EvenSeconds"/>
+         <condition name="EvenCounts"/>
      </action>
      <action name="TEST2" resulting_state="INITIAL">
-         <condition name="!EvenSeconds"/>
+         <condition name="!EvenCounts"/>
      </action>
      <action name="FORWARD" resulting_state="SECOND"/>
  </state>

--- a/t/workflow_cached_condition_condition.xml
+++ b/t/workflow_cached_condition_condition.xml
@@ -1,4 +1,4 @@
 <conditions>
-   <condition name="EvenSeconds"
-              class="TestCachedApp::Condition::EvenSeconds"/>
+   <condition name="EvenCounts"
+              class="TestCachedApp::Condition::EvenCounts"/>
 </conditions>


### PR DESCRIPTION
# Description

By replacing sleep(1) and time() with a counter, it's no longer needed to
wait for time to advance by a second to achieve the same side-effect on the
selection of the available actions.

Fixes/addresses my itch to have the test suite complete as quickly as it can.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
