### PR TITLE
Close #5: Add knob to prevent caching of condition results

### DIFF
--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -5,6 +5,7 @@ use strict;
 use base qw( Workflow::Base );
 use Carp qw(croak);
 
+$Workflow::Condition::CACHE_RESULTS = 1;
 $Workflow::Condition::VERSION = '1.48';
 
 my @FIELDS = qw( name class );
@@ -202,6 +203,11 @@ feature - if you have both C<<condition name="some_condition">> and
 C<<condition name="!some_condition">> in your workflow state definition,
 exactly one of them will succeed and one will fail - which is particularly
 useful if you use "autorun" a lot.
+
+Caching can be disabled by changing C<$Workflow::Condition::CACHE_RESULTS>
+to zero (0):
+
+    $Workflow::Condition::CACHE_RESULTS = 0;
 
 =head1 COPYRIGHT
 

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -4,6 +4,7 @@ use warnings;
 use strict;
 use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
+use Workflow::Condition;
 use Workflow::Condition::Evaluate;
 use Workflow::Exception qw( workflow_error condition_error );
 use Exception::Class;
@@ -125,7 +126,8 @@ sub evaluate_action {
                 "Condition starts with a !: '$condition_name'");
         }
 
-        if ( exists $self->{'_condition_result_cache'}->{$orig_condition} ) {
+        if ( $Workflow::Condition::CACHE_RESULTS
+             && exists $self->{'_condition_result_cache'}->{$orig_condition} ) {
 
             # The condition has already been evaluated and the result
             # has been cached

--- a/t/TestCachedApp/Condition/EvenCounts.pm
+++ b/t/TestCachedApp/Condition/EvenCounts.pm
@@ -6,7 +6,7 @@ use strict;
 use base qw( Workflow::Condition );
 use Workflow::Exception qw( condition_error );
 
-my $count = 0;
+our $count = 0;
 
 sub evaluate {
     my ( $self, $wf ) = @_;

--- a/t/uncached_conditions.t
+++ b/t/uncached_conditions.t
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+no warnings 'once';
+
+use lib 't';
+use Test::More;
+use TestUtil;
+use Workflow::Condition;
+use Workflow::Factory;
+use Data::Dumper;
+
+plan tests => 3;
+
+$Workflow::Condition::CACHE_RESULTS = 0;
+
+
+
+my $factory = Workflow::Factory->instance();
+$factory->add_config_from_file(
+    workflow  => "workflow_cached_condition.xml",
+    action    => "workflow_cached_condition_action.xml",
+    condition => "workflow_cached_condition_condition.xml",
+);
+TestUtil->init_mock_persister();
+my $wf = $factory->create_workflow( 'CachedCondition' );
+my $does_change;
+
+my @actions = $wf->get_current_actions();
+# due to hash randomization, it can be the case that either !EvenCounts
+# is executed befor EvenCounts or the other way around. This results in
+# either 1 or 3 items being returned on Perl versions with randomization
+ok(scalar @actions, 'Actions available');
+my $old_actions = join q{, }, sort @actions;
+
+CHECK_TIME_CHANGE:
+for (my $i = 0; $i < 5; $i++) {
+    my $curr_actions = join q{, }, sort ( $wf->get_current_actions() );
+    if ($old_actions ne $curr_actions) {
+        # the current action is not the one from before, this is good
+        # as we need to recheck the conditions everytime someone wants
+        # a list of all actions
+        $does_change = 1;
+        last CHECK_TIME_CHANGE;
+    }
+    $old_actions = $curr_actions;
+
+    # Change the external state the conditions depend on
+    $TestCachedApp::Condition::EvenCounts::count++;
+}
+ok($does_change, 'Available actions change with external state');
+
+$does_change = 0;
+CHECK_STATE_CHANGE:
+for (my $i = 0; $i < 5; $i++) {
+    # execute a null action to go to the second state
+    $wf->execute_action('FORWARD');
+    # and go back again
+    $wf->execute_action('BACK');
+
+    my $curr_actions = join q{, }, sort ( $wf->get_current_actions() );
+    #diag $curr_actions;
+    if ($old_actions ne $curr_actions) {
+        # the current action is not the one from before, this is good
+        # as we need to recheck the conditions everytime someone wants
+        # a list of all actions
+        $does_change = 1;
+        last CHECK_STATE_CHANGE;
+    }
+    $old_actions = $curr_actions;
+}
+ok($does_change, 'Available actions change when changing states');
+


### PR DESCRIPTION
# Description

As the project indicated interest in a general "knob" to disable condition caching, here's the implemenetation.

Fixes/addresses (If applicable) #5 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
