### PR TITLE
Add (TODO) tests to assert workflow independence with condition caching

### DIFF
--- a/t/workflow_cached_condition.xml
+++ b/t/workflow_cached_condition.xml
@@ -9,7 +9,12 @@
      <action name="TEST2" resulting_state="INITIAL">
          <condition name="!EvenCounts"/>
      </action>
-     <action name="FORWARD" resulting_state="SECOND"/>
+     <action name="FORWARD" resulting_state="SECOND">
+       <condition name="!Alternative"/>
+     </action>
+     <action name="FORWARD-ALT" resulting_state="SECOND">
+       <condition name="Alternative"/>
+     </action>
  </state>
  <state name="SECOND">
      <action name="BACK" resulting_state="INITIAL"/>

--- a/t/workflow_cached_condition_action.xml
+++ b/t/workflow_cached_condition_action.xml
@@ -3,6 +3,8 @@
            class="Workflow::Action::Null"/>
    <action name="FORWARD"
            class="Workflow::Action::Null"/>
+   <action name="FORWARD-ALT"
+           class="Workflow::Action::Null"/>
    <action name="BACK"
            class="Workflow::Action::Null"/>
 </actions>

--- a/t/workflow_cached_condition_condition.xml
+++ b/t/workflow_cached_condition_condition.xml
@@ -1,4 +1,7 @@
 <conditions>
    <condition name="EvenCounts"
               class="TestCachedApp::Condition::EvenCounts"/>
+   <condition name="Alternative"
+              class="Workflow::Condition::Evaluate"
+              test="$context->{alternative}"/>
 </conditions>


### PR DESCRIPTION
# Description

With multiple workflows in-flight, we want workflow state (including
available actions) of one to be independent of any of the others. The
cache should not be of influence.

The tests are marked TODO, because at this time, the cache *is*
influencing the outcome of unrelated workflows.

Relates to #9.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
