### PR TITLE
Condition cache instance

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -142,7 +142,7 @@ sub execute_action {
             $autorun );
 
         # clear condition cache on state change
-        $new_state_obj->clear_condition_cache();
+        delete $self->{'_condition_result_cache'};
     }
 
     if ( $new_state_obj->autorun ) {

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -134,15 +134,14 @@ sub execute_action {
         croak $error;
     }
 
+    # clear condition cache on state change
+    delete $self->{'_condition_result_cache'};
     $self->notify_observers( 'execute', $old_state, $action_name, $autorun );
 
     my $new_state_obj = $self->_get_workflow_state;
     if ( $old_state ne $new_state ) {
         $self->notify_observers( 'state change', $old_state, $action_name,
             $autorun );
-
-        # clear condition cache on state change
-        delete $self->{'_condition_result_cache'};
     }
 
     if ( $new_state_obj->autorun ) {

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -209,6 +209,10 @@ to zero (0):
 
     $Workflow::Condition::CACHE_RESULTS = 0;
 
+All versions before 1.49 used a mechanism that effectively caused global
+state. To address the problems that resulted (see GitHub issues #9 and #7),
+1.49 switched to a new mechanism with a cache per workflow instance.
+
 =head1 COPYRIGHT
 
 Copyright (c) 2003-2007 Chris Winters. All rights reserved.

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -611,7 +611,9 @@ Returns name of action to be used for autorunning the state.
 
 =head3 clear_condition_cache ( )
 
-Empties the condition result cache for a given state.
+Deprecated, kept for 1.49 compatibility.
+
+Used to empties the condition result cache for a given state.
 
 =head1 PROPERTIES
 

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -45,7 +45,7 @@ sub get_available_action_names {
 
     # assuming that the user wants the _fresh_ list of available actions,
     # we clear the condition cache before checking which ones are available
-    $self->clear_condition_cache();
+    delete $wf->{'_condition_result_cache'};
 
     foreach my $action_name (@all_actions) {
 
@@ -84,11 +84,7 @@ sub is_action_available {
 
 sub clear_condition_cache {
     my ($self) = @_;
-    foreach my $condition ( keys %{ $self->{'_condition_result_cache'} } ) {
-        delete $self->{'_condition_result_cache'}->{$condition};
-        $log->is_debug
-            && $log->debug("Deleted cached condition result for $condition");
-    }
+    return; # left for backward compatibility with 1.49
 }
 
 sub evaluate_action {
@@ -127,19 +123,19 @@ sub evaluate_action {
         }
 
         if ( $Workflow::Condition::CACHE_RESULTS
-             && exists $self->{'_condition_result_cache'}->{$orig_condition} ) {
+             && exists $wf->{'_condition_result_cache'}->{$orig_condition} ) {
 
             # The condition has already been evaluated and the result
             # has been cached
             $log->is_debug
                 && $log->debug(
                 "Condition has been cached: '$orig_condition', cached result: ",
-                $self->{'_condition_result_cache'}->{$orig_condition}
+                $wf->{'_condition_result_cache'}->{$orig_condition}
                 );
             if ( !$opposite ) {
                 $log->is_debug
                     && $log->debug("Opposite is false.");
-                if ( !$self->{'_condition_result_cache'}->{$orig_condition} )
+                if ( !$wf->{'_condition_result_cache'}->{$orig_condition} )
                 {
                     $log->is_debug
                         && $log->debug("Cached condition result is false.");
@@ -154,7 +150,7 @@ sub evaluate_action {
                 # condition did NOT fail
                 $log->is_debug
                     && $log->debug("Opposite is true.");
-                if ( $self->{'_condition_result_cache'}->{$orig_condition} ) {
+                if ( $wf->{'_condition_result_cache'}->{$orig_condition} ) {
                     $log->is_debug
                         && $log->debug("Cached condition is true.");
                     condition_error "No access to action '$action_name' in ",
@@ -187,7 +183,7 @@ sub evaluate_action {
                 if (Exception::Class->caught('Workflow::Exception::Condition')) {
                     # TODO: We may just want to pass the error up
                     # without wrapping it...
-                    $self->{'_condition_result_cache'}->{$orig_condition} = 0;
+                    $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
                     if ( !$opposite ) {
                         $log->is_debug
                             && $log->debug("No access to action '$action_name', condition " .
@@ -214,7 +210,7 @@ sub evaluate_action {
                         => "Got unknown exception while handling condition '$condition_name' / " . $ee );
                 }
             } else {
-                $self->{'_condition_result_cache'}->{$orig_condition} = 1;
+                $wf->{'_condition_result_cache'}->{$orig_condition} = 1;
                 if ($opposite) {
 
                     $log->is_debug

--- a/t/cached_conditions.t
+++ b/t/cached_conditions.t
@@ -72,36 +72,33 @@ ok( ( $actions =~ m/FORWARD-ALT,/ ) ,
 $wf->context->param( alternative => '' );
 
 
-TODO: {
-     # With one workflow in-flight, results of the other should
-     # not be influenced. So we create a second workflow which
-     # does *not* have FORWARD in its list of current actions and
-     # then we ask the original workflow (which *does* have it)
-     # for the fields in the action
+# With one workflow in-flight, results of the other should
+# not be influenced. So we create a second workflow which
+# does *not* have FORWARD in its list of current actions and
+# then we ask the original workflow (which *does* have it)
+# for the fields in the action
 
-     # The result should be an (empty) list, but it is currently
-     # an exception saying that the action isn't in the state's
-     # list of actions.
+# The result should be an (empty) list, but it is currently
+# an exception saying that the action isn't in the state's
+# list of actions.
 
-     my $actions = join( ', ', $wf->get_current_actions(), '' );
-     ok( ( $actions =~ m/FORWARD,/ ),
-         'FORWARD action is available in the original workflow' );
-     my $wfa = $factory->create_workflow('CachedCondition');
-     $wfa->context->param(alternative => 'yes');
-     $actions = join( ', ', $wfa->get_current_actions(), '' );
-     ok( ( $actions =~ m/FORWARD-ALT,/ ),
-         'FORWARD-ALT action is available in the secondary workflow' );
+$actions = join( ', ', $wf->get_current_actions(), '' );
+ok( ( $actions =~ m/FORWARD,/ ),
+    'FORWARD action is available in the original workflow' );
+my $wfa = $factory->create_workflow('CachedCondition');
+$wfa->context->param(alternative => 'yes');
+$actions = join( ', ', $wfa->get_current_actions(), '' );
+ok( ( $actions =~ m/FORWARD-ALT,/ ),
+    'FORWARD-ALT action is available in the secondary workflow' );
 
-     local $TODO = 'This is a test for unresolved bug #9';
-     lives_ok( sub { $wf->get_action_fields('FORWARD') },
-               'Getting the fields on a valid action should' );
-     lives_ok( sub { $wf->execute_action('FORWARD') },
-               'Executing the available forward state succeeds' );
+lives_ok( sub { $wf->get_action_fields('FORWARD') },
+          'Getting the fields on a valid action should' );
+lives_ok( sub { $wf->execute_action('FORWARD') },
+          'Executing the available forward state succeeds' );
 
-     is( $wf->state, 'SECOND',
-         'The original workflow changed state successfully');
-     is( $wfa->state, 'INITIAL',
-         'The secondary workflow is unaffected by changes to original');
+is( $wf->state, 'SECOND',
+    'The original workflow changed state successfully');
+is( $wfa->state, 'INITIAL',
+    'The secondary workflow is unaffected by changes to original');
 
-}
 


### PR DESCRIPTION
# Description

As demonstrated by the failing(TODO) tests in t/cached_conditions.t, two workflow instances of the same type influence each other due to depending on the same (global) condition cache. This commit changes the cache to be per-workflow instance, removing the (undesirable) cross influence.

Additionally, as discussed earlier today, this PR also clears the condition cache unconditionally after a successful state transition, because state transitions (even to "$self") should be considered to have side-effects.

Fixes/addresses #9 

**NOTE** This is a draft PR. I'm working on a second PR, for evaluation of the two strategies.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
