### PR TITLE
Cache condition only local to the evaluation scope

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -140,9 +140,6 @@ sub execute_action {
     if ( $old_state ne $new_state ) {
         $self->notify_observers( 'state change', $old_state, $action_name,
             $autorun );
-
-        # clear condition cache on state change
-        $new_state_obj->clear_condition_cache();
     }
 
     if ( $new_state_obj->autorun ) {

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -209,6 +209,10 @@ to zero (0):
 
     $Workflow::Condition::CACHE_RESULTS = 0;
 
+All versions before 1.49 used a mechanism that effectively caused global
+state. To address the problems that resulted (see GitHub issues #9 and #7),
+1.49 switched to a new mechanism local to the point of evaluation.
+
 =head1 COPYRIGHT
 
 Copyright (c) 2003-2007 Chris Winters. All rights reserved.

--- a/t/cached_conditions.t
+++ b/t/cached_conditions.t
@@ -72,36 +72,32 @@ ok( ( $actions =~ m/FORWARD-ALT,/ ) ,
 $wf->context->param( alternative => '' );
 
 
-TODO: {
-     # With one workflow in-flight, results of the other should
-     # not be influenced. So we create a second workflow which
-     # does *not* have FORWARD in its list of current actions and
-     # then we ask the original workflow (which *does* have it)
-     # for the fields in the action
+# With one workflow in-flight, results of the other should
+# not be influenced. So we create a second workflow which
+# does *not* have FORWARD in its list of current actions and
+# then we ask the original workflow (which *does* have it)
+# for the fields in the action
 
-     # The result should be an (empty) list, but it is currently
-     # an exception saying that the action isn't in the state's
-     # list of actions.
+# The result should be an (empty) list, but it is currently
+# an exception saying that the action isn't in the state's
+# list of actions.
 
-     my $actions = join( ', ', $wf->get_current_actions(), '' );
-     ok( ( $actions =~ m/FORWARD,/ ),
-         'FORWARD action is available in the original workflow' );
-     my $wfa = $factory->create_workflow('CachedCondition');
-     $wfa->context->param(alternative => 'yes');
-     $actions = join( ', ', $wfa->get_current_actions(), '' );
-     ok( ( $actions =~ m/FORWARD-ALT,/ ),
-         'FORWARD-ALT action is available in the secondary workflow' );
+$actions = join( ', ', $wf->get_current_actions(), '' );
+ok( ( $actions =~ m/FORWARD,/ ),
+    'FORWARD action is available in the original workflow' );
+my $wfa = $factory->create_workflow('CachedCondition');
+$wfa->context->param(alternative => 'yes');
+$actions = join( ', ', $wfa->get_current_actions(), '' );
+ok( ( $actions =~ m/FORWARD-ALT,/ ),
+    'FORWARD-ALT action is available in the secondary workflow' );
 
-     local $TODO = 'This is a test for unresolved bug #9';
-     lives_ok( sub { $wf->get_action_fields('FORWARD') },
-               'Getting the fields on a valid action should' );
-     lives_ok( sub { $wf->execute_action('FORWARD') },
-               'Executing the available forward state succeeds' );
+lives_ok( sub { $wf->get_action_fields('FORWARD') },
+          'Getting the fields on a valid action should' );
+lives_ok( sub { $wf->execute_action('FORWARD') },
+          'Executing the available forward state succeeds' );
 
-     is( $wf->state, 'SECOND',
-         'The original workflow changed state successfully');
-     is( $wfa->state, 'INITIAL',
-         'The secondary workflow is unaffected by changes to original');
-
-}
+is( $wf->state, 'SECOND',
+    'The original workflow changed state successfully');
+is( $wfa->state, 'INITIAL',
+    'The secondary workflow is unaffected by changes to original');
 


### PR DESCRIPTION
**NOTE** This is a draft PR in order to evaluate against a similar draft PR.

# Description

This change reduces the condition cache from being effectively global due
to the fact that it's shared between all instances of the same workflow, to
the smallest scope enclosing a group of condition evalations that need to
return consistent results across evaluations.

Fixes/addresses #9

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
