### PR TITLE
Add referential integrity between workflow and history tables

### DIFF
--- a/struct/workflow_mysql.sql
+++ b/struct/workflow_mysql.sql
@@ -14,6 +14,7 @@ CREATE TABLE workflow_history (
   state             varchar(30) not null,
   workflow_user     varchar(50) null,
   history_date      timestamp,
-  primary key( workflow_hist_id )
+  primary key( workflow_hist_id ),
+  foreign key( workflow_id ) references workflow( workflow_id )
 );
 

--- a/struct/workflow_other.sql
+++ b/struct/workflow_other.sql
@@ -14,6 +14,7 @@ CREATE TABLE workflow_history (
   state             varchar(30) not null,
   workflow_user     varchar(50) null,
   history_date      timestamp,
-  primary key( workflow_hist_id )
+  primary key( workflow_hist_id ),
+  foreign key( workflow_id ) references workflow( workflow_id )
 );
 

--- a/struct/workflow_pg.sql
+++ b/struct/workflow_pg.sql
@@ -16,7 +16,8 @@ CREATE TABLE workflow_history (
   state             varchar(30) not null,
   workflow_user     varchar(50) null,
   history_date      timestamp default current_timestamp,
-  primary key( workflow_hist_id )
+  primary key( workflow_hist_id ),
+  foreign key( workflow_id ) references workflow( workflow_id )
 );
 
 CREATE SEQUENCE workflow_history_seq;

--- a/struct/workflow_sqlite.sql
+++ b/struct/workflow_sqlite.sql
@@ -12,6 +12,7 @@ CREATE TABLE workflow_history (
   description       varchar(255) null,
   state             varchar(30) not null,
   workflow_user     varchar(50) null,
-  history_date      timestamp
+  history_date      timestamp,
+  foreign key (workflow_id) references workflow(workflow_id)
 );
 


### PR DESCRIPTION
# Description

Add referential integrity to the example schema files. Referential integrity is important. Always.

In all honesty, I didn't check this change on any of the database systems; I just followed the general sql syntax.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
