### PR TITLE
Quote column and table names before generating SQL strings

### DIFF
--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -210,7 +210,9 @@ sub create_workflow {
     my $sql = 'INSERT INTO %s ( %s ) VALUES ( %s )';
 
     ## no critic (ProhibitParensWithBuiltins)
-    $sql = sprintf $sql, $self->workflow_table, join( ', ', @fields ),
+    $sql = sprintf $sql,
+        $self->handle->quote_identifier( $self->workflow_table ),
+        join( ', ', @fields ),
         join( ', ', map {'?'} @values );
 
     if ( $log->is_debug ) {
@@ -246,7 +248,8 @@ sub fetch_workflow {
           FROM %s
          WHERE $WF_FIELDS[0] = ?
     };
-    $sql = sprintf $sql, $self->workflow_table;
+    $sql = sprintf $sql,
+        $self->handle->quote_identifier( $self->workflow_table );
 
     if ( $log->is_debug ) {
         $log->debug("Will use SQL\n$sql");
@@ -322,8 +325,8 @@ sub create_history {
         my $sql = 'INSERT INTO %s ( %s ) VALUES ( %s )';
 
         ## no critic (ProhibitParensWithBuiltins)
-        $sql = sprintf $sql, $self->history_table, join( ', ', @fields ),
-            join( ', ', map {'?'} @values );
+        $sql = sprintf $sql, $dbh->quote_identifier( $self->history_table ),
+            join( ', ', @fields ), join( ', ', map {'?'} @values );
         if ( $log->is_debug ) {
             $log->debug("Will use SQL\n$sql");
             $log->debug( "Will use parameters\n", join ', ', @values );
@@ -436,10 +439,14 @@ sub rollback_transaction {
 sub _init_fields {
     my ($self) = @_;
     unless ( scalar @WF_FIELDS ) {
-        @WF_FIELDS = $self->get_workflow_fields();
+        @WF_FIELDS = map {
+            $self->handle->quote_identifier($_)
+        } $self->get_workflow_fields();
     }
     unless ( scalar @HIST_FIELDS ) {
-        @HIST_FIELDS = $self->get_history_fields();
+        @HIST_FIELDS = map {
+            $self->handle->quote_identifier($_)
+        } $self->get_history_fields();
     }
 }
 

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -61,9 +61,11 @@ sub fetch_extra_workflow_data {
     my $data_field = $self->data_field;
     my $select_data_fields
         = ( ref $data_field )
-        ? join( ', ', @{$data_field} )
-        : $data_field;
-    $sql = sprintf $sql, $select_data_fields, $self->table;
+        ? join( ', ',
+                map { $self->handle->quote_identifier($_) } @{$data_field} )
+        : $self->handle->quote_identifier($data_field);
+    $sql = sprintf $sql, $select_data_fields,
+        $self->handle->quote_identifier( $self->table );
     $log->is_debug
         && $log->debug("Using SQL\n$sql");
     $log->is_debug

--- a/t/TestApp/Ticket.pm
+++ b/t/TestApp/Ticket.pm
@@ -47,8 +47,8 @@ sub fetch {
 
     my $persister = FACTORY->get_persister( 'TestPersister' );
     if ( $persister->isa( 'Workflow::Persister::DBI' ) ) {
-        my $ticket_fields = 'type, subject, description, creator, status, due_date, last_update';
-        my $sql = 'SELECT %s FROM ticket WHERE ticket_id = ?';
+        my $ticket_fields = '"type", "subject", "description", "creator", "status", "due_date", "last_update"';
+        my $sql = 'SELECT %s FROM "ticket" WHERE ticket_id = ?';
         $sql = sprintf( $sql, $ticket_fields );
         $log->debug( "Will use SQL\n$sql" );
         $log->debug( "Will use parameters: $id" );
@@ -117,8 +117,8 @@ sub create {
                          creator status due_date last_update );
         my @values = ( $id, $self->type, $self->subject, $self->description,
                        $self->creator, $self->status, $due_date, $update_date );
-        my $sql = 'INSERT INTO ticket ( %s ) VALUES ( %s )';
-        $sql = sprintf( $sql, join( ', ', @fields ),
+        my $sql = 'INSERT INTO "ticket" ( %s ) VALUES ( %s )';
+        $sql = sprintf( $sql, join( ', ', map { qq{"$_"} } @fields ),
                         join( ', ', map { '?' } @values ) );
         $log->debug( "Will use SQL\n$sql" );
         $log->debug( "Will use parameters: ", join( ', ', @values ) );

--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -48,7 +48,7 @@ sub check_workflow_history {
     my ( $class, $tracker, $values ) = @_;
     $class->check_tracker(
         $tracker, 'create workflow history',
-        qr/^INSERT INTO workflow_history \( workflow_id, action, description, state, workflow_user, history_date, workflow_hist_id \)/,
+        qr/^INSERT INTO "workflow_history" \( "workflow_id", "action", "description", "state", "workflow_user", "history_date", "workflow_hist_id" \)/,
         [ 'workflow ID', 'action', 'description',
           'state', 'user', 'current date',
           'random ID of correct length' ],
@@ -111,7 +111,7 @@ sub init_mock_persister {
         class => 'Workflow::Persister::DBI',
         dsn   => 'DBI:Mock:',
         date_format => '%Y-%m-%dT%H:%M:%S',
-	user => 'DBTester',
+        user => 'DBTester',
     );
     $factory->add_config( persister => [ \%persister ] );
 }

--- a/t/persister_dbi.t
+++ b/t/persister_dbi.t
@@ -28,7 +28,7 @@ my @persisters = ({
     user => 'DBTester',
     date_format => $DATE_FORMAT,
 });
-
+my $i = 0;
 my $factory = Workflow::Factory->instance;
 $factory->add_config( persister => \@persisters );
 TestUtil->init_factory();
@@ -53,7 +53,7 @@ my ( $wf );
     my $wf_history  = $history->[0];
     TestUtil->check_tracker(
         $wf_history, 'create workflow',
-        qr/^INSERT INTO workflow \( type, state, last_update, workflow_id \)/,
+        qr/^INSERT INTO "workflow" \( "type", "state", "last_update", "workflow_id" \)/,
         [ 'type', 'state', 'current date',
           'random ID of correct length' ],
         [ 'Ticket', 'INITIAL', $wf_history->{bound_params}->[2],
@@ -89,7 +89,7 @@ my ( $wf );
     my %ticket_info = TestUtil->get_new_ticket_info();
     TestUtil->check_tracker(
         $tix_create, 'create ticket',
-        qr/^INSERT INTO ticket \( ticket_id, type, subject, description, creator, status, due_date, last_update \)/,
+        qr/^INSERT INTO "ticket" \( "ticket_id", "type", "subject", "description", "creator", "status", "due_date", "last_update" \)/,
         [ 'ticket ID', 'type', 'subject',
           'description', 'creator', 'status',
           'due date', 'last update' ],


### PR DESCRIPTION
# Description

By quoting identifiers, users are free to use SQL keywords in their
column and table names.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
