### PR TITLE
Make sure the generator is loaded before calling its `new()` method

### DIFF
--- a/lib/Workflow/Persister.pm
+++ b/lib/Workflow/Persister.pm
@@ -3,6 +3,7 @@ package Workflow::Persister;
 use warnings;
 use strict;
 use base qw( Workflow::Base );
+use English qw( -no_match_vars );
 use Log::Log4perl qw( get_logger );
 use Workflow::Exception qw( persist_error );
 
@@ -55,7 +56,10 @@ sub assign_generators {
 
 sub init_random_generators {
     my ( $self, $params ) = @_;
+    my $log = get_logger();
     my $length = $params->{id_length} || DEFAULT_ID_LENGTH;
+    eval { require Workflow::Persister::RandomId };
+    $log->error($EVAL_ERROR) if $EVAL_ERROR;
     my $generator
         = Workflow::Persister::RandomId->new( { id_length => $length } );
     return ( $generator, $generator );
@@ -63,6 +67,9 @@ sub init_random_generators {
 
 sub init_uuid_generators {
     my ( $self, $params ) = @_;
+    my $log = get_logger();
+    eval { require Workflow::Persister::UUID };
+    $log->error($EVAL_ERROR) if $EVAL_ERROR;
     my $generator = Workflow::Persister::UUID->new();
     return ( $generator, $generator );
 }


### PR DESCRIPTION

# Description

A work-around exists by requiring the application to load the generator
class. It won't hurt to service the user by `require`-ing the class
just before we actually need it. Using `require` rather than `use`
makes sure we don't import any unwanted or not-installed dependencies.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
