### PR TITLE
Make the InEnumeratedType adhere to the Validator protocol

### DIFF
--- a/TODO
+++ b/TODO
@@ -18,10 +18,6 @@ TODO file for Workflow
 
 - Document relation between actions and validators
 
-- Investigate if either Workflow::Validator::InEnumeratedType or
-  Workflow::Validator::MatchesDateFormat are violating an (undefined) abstract 
-  class. One holds a validate method the other a validator method.
-
 - Add support for string based configuration instead of file based (copying
   behavior from XML::Simple) ?
 

--- a/lib/Workflow/Validator/InEnumeratedType.pm
+++ b/lib/Workflow/Validator/InEnumeratedType.pm
@@ -23,7 +23,7 @@ sub _init {
     $self->add_enumerated_values(@values);
 }
 
-sub validator {
+sub validate {
     my ( $self, $wf, $value ) = @_;
     unless ( $self->is_enumerated_value($value) ) {
         validation_error "Value '$value' must be one of: ", join ", ",
@@ -173,9 +173,9 @@ It uses L</add_enumerated_values> to add the set of values for enumeration.
 The primary parameter is value, which should be used to specify the
 either a single value or a reference to array of values to be added.
 
-=head3 validator
+=head3 validate
 
-The validator method is the public API. It encapulates L</is_enumerated:value>
+The validate method is the public API. It encapulates L</is_enumerated:value>
 and works with L<Workflow>.
 
 =head3 add_enumerated_values( @values )

--- a/t/validator_in_enumerated_type.t
+++ b/t/validator_in_enumerated_type.t
@@ -44,6 +44,6 @@ ok(@enumerated_values = $validator->get_enumerated_values());
 
 is(scalar @enumerated_values, 3);
 
-ok($validator->validator(undef, 'foo'));
+ok($validator->validate(undef, 'foo'));
 
-dies_ok { $validator->validator(undef, 'bad'); };
+dies_ok { $validator->validate(undef, 'bad'); };


### PR DESCRIPTION

# Description

The abstract super-type is no longer undefined and defines the
entry point for validation to be named `validate()`.

Fixes an issue listed in `TODO`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
