### PR TITLE
Fix LazyAND condition failing when nested condition returns a string

### DIFF
--- a/lib/Workflow/Condition/LazyAND.pm
+++ b/lib/Workflow/Condition/LazyAND.pm
@@ -40,7 +40,7 @@ sub evaluate {
         if ( not $result ) {
             condition_error("Condition '$cond' returned 'false'");
         }
-        $total += $result;
+        $total++;
     }
 
     return $total


### PR DESCRIPTION

# Description

As shown by the CheckReturn condition, conditions can return any value
that is interpreted as true or false, not just zero or one (or even a
number).

Since the result is used to check that more than a single condition was
evaluated, there's no need to use the condition result.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
