### PR TITLE
Fix GreedyOR assumption on `evaluate_condition` return type

### DIFF
--- a/lib/Workflow/Condition/GreedyOR.pm
+++ b/lib/Workflow/Condition/GreedyOR.pm
@@ -36,7 +36,7 @@ sub evaluate {
     my $result = 0;
 
     foreach my $cond ( @{$conditions} ) {
-        $result += $self->evaluate_condition( $wf, $cond );
+        $result += $self->evaluate_condition( $wf, $cond ) ? 1 : 0;
     }
 
     if ($result) {


### PR DESCRIPTION

# Description

The return type of `evaluate_condition()` may be non-numeric when the
underlying condition returns a non-numeric boolean value (e.g. empty string).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
