### PR TITLE
Don't require a DSN when DBI handle comes from elsewhere

### DIFF
--- a/t/TestPersisterElsewhere.pm
+++ b/t/TestPersisterElsewhere.pm
@@ -1,0 +1,9 @@
+package TestPersisterElsewhere;
+
+use strict;
+use warnings;
+use base qw( Workflow::Persister::DBI );
+
+sub create_handle { return undef; }
+
+1;


### PR DESCRIPTION
# Description

The current initialization of the DBI persister requires a DSN, even when the handle is being retrieved from a secondary source (that is: the driver doesn't create it itself). This leads to duplicate configuration.

The DBI interface guarantees that the driver name is available from the driver handle, though, allowing to retrieve the bit we need from the DSN to be gotten from the handle without configuration, instead. If no handle is available, check for the `driver` configuration key.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
