### PR TITLE
Issue52

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Perl extension Workflow
 
-1.49 2021-01-08 Maintenance and minor feature release, update not required
+1.49 2021-01-12 Maintenance and minor feature release, update not required
 
 - Addressed an issue with return values from Workflow::Condition::GreedyOR's `evaluate_condition`, PR #50 from Erik Huelsmann
 

--- a/t/05_condition_nested.t
+++ b/t/05_condition_nested.t
@@ -4,6 +4,7 @@
 
 use strict;
 use warnings;
+use lib qw(../lib lib ../t t);
 
 use Test::More;
 

--- a/t/action.t
+++ b/t/action.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::Exception;
 use Test::More  tests => 3;

--- a/t/action_field.t
+++ b/t/action_field.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::Exception;
 use Test::More  tests => 16;
@@ -16,7 +16,7 @@ dies_ok { $action = Workflow::Action::InputField->new({}) };
 
 ok($action = Workflow::Action::InputField->new({
     name        => 'test',
-    is_required => 'yes', 
+    is_required => 'yes',
 }));
 
 isa_ok($action, 'Workflow::Action::InputField');
@@ -42,7 +42,7 @@ is($action->is_optional, 'no');
 
 ok($action = Workflow::Action::InputField->new({
     name        => 'test',
-    is_required => 'no', 
+    is_required => 'no',
 }));
 
 is($action->is_required, 'no');

--- a/t/action_mailer.t
+++ b/t/action_mailer.t
@@ -3,7 +3,7 @@
 # $Id: action_null.t 217 2004-12-09 16:02:45Z cwinters $
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 2;
 

--- a/t/action_null.t
+++ b/t/action_null.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 2;
 

--- a/t/action_validate.t
+++ b/t/action_validate.t
@@ -4,7 +4,7 @@
 
 use strict;
 use warnings;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::Exception;
 use Test::More tests => 13;

--- a/t/add_config_bug.t
+++ b/t/add_config_bug.t
@@ -1,9 +1,9 @@
-#!/usr/bin/perl 
+#!/usr/bin/perl
 
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use constant NUM_TESTS => 4;
 use Test::More;

--- a/t/base.t
+++ b/t/base.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 26;
 

--- a/t/cached_conditions.t
+++ b/t/cached_conditions.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
-
-use lib 't';
+use lib qw(../lib lib ../t t);
 use Test::More;
 use Test::Exception;
 use TestUtil;

--- a/t/condition.t
+++ b/t/condition.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 11;
 use Test::Exception;

--- a/t/condition_evaluate.t
+++ b/t/condition_evaluate.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 1;
 

--- a/t/config.t
+++ b/t/config.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 50;
 use Test::Exception;
@@ -55,7 +55,7 @@ dies_ok { $parser->parse( '123_NOSUCHTYPE', 'workflow_errorprone.perl' ) };
 dies_ok { Workflow::Config->parse() };
 
 my @config = $parser->parse( 'workflow' );
-is(scalar(@config), 0, 'forgotten file, asserting length of array returned'); 
+is(scalar(@config), 0, 'forgotten file, asserting length of array returned');
 
 my %config_perl = (
 		   'workflow' => ['workflow.perl', 'workflow_type.perl', 'workflow_type_alternate_initial.perl'],

--- a/t/context-persists.t
+++ b/t/context-persists.t
@@ -8,7 +8,7 @@ use if $ENV{DEBUG} => "Smart::Comments";
 use File::Temp;               # don't leave any traces :)
 use Env qw($TEST_VERBOSE);
 
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 
 #use Log::Log4perl ":easy";    # makes workflow happy

--- a/t/context.t
+++ b/t/context.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 9;
 use Test::Exception;
@@ -27,5 +27,4 @@ is($other_context->param('argle'), 'bargle');
 lives_ok { $context->merge($other_context); };
 
 is($context->param('argle'), 'bargle');
-   
-   
+

--- a/t/exception.t
+++ b/t/exception.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 1;
 

--- a/t/factory.t
+++ b/t/factory.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 7;
 use Test::Exception;

--- a/t/factory_callback_config.t
+++ b/t/factory_callback_config.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More tests => 7;
 use Test::Exception;

--- a/t/factory_subclass.t
+++ b/t/factory_subclass.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 5;
 

--- a/t/history.t
+++ b/t/history.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 18;
 

--- a/t/persister.t
+++ b/t/persister.t
@@ -3,7 +3,7 @@
 # $Id: Persister.t 304 2007-07-03 14:56:43Z jonasbn $
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::Exception;
 use Test::More  tests => 6;

--- a/t/persister_dbi.t
+++ b/t/persister_dbi.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use constant NUM_TESTS => 43;
 use Test::More;

--- a/t/persister_dbi_extra_data.t
+++ b/t/persister_dbi_extra_data.t
@@ -5,6 +5,7 @@
 use strict;
 use constant NUM_TESTS => 1;
 use Test::More;
+use lib qw(../lib lib ../t t);
 
 eval "require DBI";
 if ( $@ ) {

--- a/t/persister_dbi_sqlite.t
+++ b/t/persister_dbi_sqlite.t
@@ -2,7 +2,7 @@
 
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use constant NUM_TESTS => 15;
 use Test::More;

--- a/t/persister_file.t
+++ b/t/persister_file.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use File::Path            qw( rmtree );
 use File::Spec::Functions qw( catdir curdir rel2abs );

--- a/t/persister_random_id.t
+++ b/t/persister_random_id.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More tests => 10;
 

--- a/t/persister_spops.t
+++ b/t/persister_spops.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 
 use constant NUM_TESTS => 18;

--- a/t/persister_uuid.t
+++ b/t/persister_uuid.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 
 use constant NUM_TESTS => 7;

--- a/t/state.t
+++ b/t/state.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 21;
 

--- a/t/state_perl.t
+++ b/t/state_perl.t
@@ -1,7 +1,7 @@
 # -*-perl-*-
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 19;
 

--- a/t/uncached_conditions.t
+++ b/t/uncached_conditions.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 no warnings 'once';
 
-use lib 't';
+use lib qw(../lib lib ../t t);
 use Test::More;
 use TestUtil;
 use Workflow::Condition;

--- a/t/validator.t
+++ b/t/validator.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 2;
 use Test::Exception;

--- a/t/validator_has_required_field.t
+++ b/t/validator_has_required_field.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More  tests => 1;
 

--- a/t/validator_in_enumerated_type.t
+++ b/t/validator_in_enumerated_type.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::Exception;
 use Test::More tests => 16;

--- a/t/validator_matches_date_format.t
+++ b/t/validator_matches_date_format.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::Exception;
 use DateTime;
@@ -33,6 +33,6 @@ my $dt = DateTime->new( year   => 1964,
                      nanosecond => 500000000,
                      time_zone => 'Asia/Taipei',
                    );
-         
+
 lives_ok { $validator->validate($wf, $dt) };
 

--- a/t/workflow.t
+++ b/t/workflow.t
@@ -3,7 +3,7 @@
 # $Id$
 
 use strict;
-use lib 't';
+use lib qw(../lib lib ../t t);
 use TestUtil;
 use Test::More;
 use Test::Exception;


### PR DESCRIPTION
# Description

This adjusts all `lib` statements in the test suite to support the lack of default inclusion of `.`

See issue #52 for details

Fixes #52 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
