### PR TITLE
Resolve #55 by classifying the various `*fields()` methods as public

### DIFF
--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -384,18 +384,6 @@ current $wf_state. Your milage may vary.
   1;
 
 
-=head2 Private Methods
-
-=head3 init( $workflow, \%params )
-
-init is called in conjuction with the overall workflow initialization.
-
-It sets up the necessary validators based on the on configured actions, input fields and required fields.
-
-=head3 add_field( @fields )
-
-Add one or more L<Workflow::Action::InputField>s to the action.
-
 =head3 required_fields()
 
 Return a list of L<Workflow::Action::InputField> objects that are required.
@@ -408,6 +396,19 @@ Return a list of L<Workflow::Action::InputField> objects that are optional.
 
 Return a list of all L<Workflow::Action::InputField> objects
 associated with this action.
+
+
+=head2 Private Methods
+
+=head3 init( $workflow, \%params )
+
+init is called in conjuction with the overall workflow initialization.
+
+It sets up the necessary validators based on the on configured actions, input fields and required fields.
+
+=head3 add_field( @fields )
+
+Add one or more L<Workflow::Action::InputField>s to the action.
 
 =head3 add_validators( @validator_config )
 


### PR DESCRIPTION

# Description

By reclassifying these methods as public, they become available for
consumers of Workflow. This makes sense once the action instances
become accessible by callers in order to provide access to their
extra properties (as intended by #54).

Fixes/addresses #55

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
