### PR TITLE
Re #10: Work around bug in Class::Observable observing instances

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -350,6 +350,19 @@ sub _auto_execute_state {
     }
 }
 
+# This DESTROY method is a work-around for the problem with Class::Observable
+# that when an instance gets allocated in *exactly* the same address as an
+# earlier instance (which has since been destroyed), the observer registration
+# was actually *not* destroyed and the observers are applied to the new
+# instance. See gh issue #10.
+sub DESTROY {
+    my ($self) = @_;
+
+    # ignore all errors: during interpreter shutdown, none of the wrapped
+    # code is expected to work...
+    eval { $self->delete_all_observers() };
+}
+
 1;
 
 __END__


### PR DESCRIPTION
# Description

Works around a bug in Class::Observable where observers are registered by memory address and not cleared when the value at that address is destroyed.

Relates to #10.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
