### PR TITLE
Fix #10: observer tests fail

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -74,7 +74,6 @@ meta_noindex    = 1    ;optional flag
 perl                       = 5.006
 Class::Accessor            = 0.18
 Class::Factory             = 1.00
-Class::Observable          = 1.04
 DateTime                   = 0.15
 DateTime::Format::Strptime = 1.00
 Exception::Class           = 1.10

--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -1,8 +1,7 @@
 package Workflow::Action;
 
 # Note: we may implement a separate event mechanism so that actions
-# can trigger other code (use 'Class::Observable'? read observations
-# from database?)
+# can trigger other code (to read observations from database?)
 
 use warnings;
 use strict;

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -281,7 +281,7 @@ sub _load_observers {
             $self->_load_class( $observer_class,
                       "Cannot require observer '%s' to watch observer "
                     . "of type '$wf_type': %s" );
-            push @observers, $observer_class;
+            push @observers, sub { $observer_class->update(@_) };
         } elsif ( my $observer_sub = $observer_info->{sub} ) {
             my ( $observer_class, $observer_sub )
                 = $observer_sub =~ /^(.*)::(.*)$/;


### PR DESCRIPTION
# Description

Replace Class::Observer by something much simpler. Class::Observer
allows one to install observers on classes, their parents as well as
their instances. This is much more functionality then Workflow needs
as it only installs observers on instances.

As documented in issue #10, Class::Observer gets the installation of
observers on instances, in all its complexity, wrong -- resulting in
a small memory leak as well as non-deterministic behaviour.

**NOTE** this PR is a proposal and fails the documentation requirements for the two methods `add_observer` and `notify_observers`. This is intentional: I'd like to discuss whether these two methods would need to be in `Workflow` or in `Workflow::Base`, where they don't get documented as prominently as in the Workflow docs.

**NOTE 2** I've verified this proposal against the OpenXPKI repository; they seem to be using only the `notify_observers` method, which used to be inherited from `Class::Observable` and this proposal adds to `Workflow` instead.

Fixes/addresses #10

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

