### PR TITLE
Remove unused Log::Dispatch dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -78,7 +78,6 @@ Class::Observable          = 1.04
 DateTime                   = 0.15
 DateTime::Format::Strptime = 1.00
 Exception::Class           = 1.10
-Log::Dispatch              = 2.00
 Log::Log4perl              = 0.34
 Safe                       = 0
 XML::Simple                = 2.00

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -1151,8 +1151,6 @@ to L<Workflow::Config>, for implementation details.
 
 =item L<Exception::Class>
 
-=item L<Log::Dispatch>
-
 =item L<Log::Log4perl>
 
 =item L<Safe>


### PR DESCRIPTION
# Description

Nothing uses Log::Dispatch, so it seems only appropriate to remove it from the dependency list.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
