### PR TITLE
Remove dependency declaration for CORE modules

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -82,8 +82,6 @@ Log::Log4perl              = 0.34
 Safe                       = 0
 XML::Simple                = 2.00
 DBI                        = 0
-Data::Dumper               = 0
-Carp                       = 0
 File::Slurp                = 0
 Data::UUID                 = 0
 


### PR DESCRIPTION
# Description

Carp and Data::Dumper have been in core since 5.6.0 (and much longer before that). The deps don't include 'strict', 'warnings' or 'base' either...

## Type of change

Cleanup.

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

