### PR TITLE
Removal of CVS/SVN legacy

### DIFF
--- a/eg/ticket/App/Action/TicketComment.pm
+++ b/eg/ticket/App/Action/TicketComment.pm
@@ -1,7 +1,5 @@
 package App::Action::TicketComment;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Action );
 use Log::Log4perl qw( get_logger );

--- a/eg/ticket/App/Action/TicketCreate.pm
+++ b/eg/ticket/App/Action/TicketCreate.pm
@@ -1,7 +1,5 @@
 package App::Action::TicketCreate;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Action );
 use App::Ticket;

--- a/eg/ticket/App/Action/TicketUpdate.pm
+++ b/eg/ticket/App/Action/TicketUpdate.pm
@@ -1,6 +1,6 @@
 package App::Action::TicketUpdate;
 
-# $Id$
+
 
 use strict;
 use base qw( Workflow::Action );

--- a/eg/ticket/App/Condition/HasUserAndTicket.pm
+++ b/eg/ticket/App/Condition/HasUserAndTicket.pm
@@ -1,6 +1,6 @@
 package App::Condition::HasUserAndTicket;
 
-# $Id$
+
 
 use strict;
 use base qw( Workflow::Condition );

--- a/eg/ticket/App/Condition/IsCreator.pm
+++ b/eg/ticket/App/Condition/IsCreator.pm
@@ -1,6 +1,6 @@
 package App::Condition::IsCreator;
 
-# $Id$
+
 
 use strict;
 use base qw( Workflow::Condition );

--- a/eg/ticket/App/Condition/IsWorker.pm
+++ b/eg/ticket/App/Condition/IsWorker.pm
@@ -1,6 +1,6 @@
 package App::Condition::IsWorker;
 
-# $Id$
+
 
 use strict;
 use base qw( Workflow::Condition );

--- a/eg/ticket/App/User.pm
+++ b/eg/ticket/App/User.pm
@@ -1,7 +1,5 @@
 package App::User;
 
-# $Id$
-
 use strict;
 
 $App::User::VERSION = '1.01';

--- a/eg/ticket/ticket_web.pl
+++ b/eg/ticket/ticket_web.pl
@@ -1,7 +1,5 @@
 #!/usr/bin/perl
 
-# $Id$
-
 use strict;
 use App::Web;
 use CGI;

--- a/t/05_condition_nested.t
+++ b/t/05_condition_nested.t
@@ -1,6 +1,4 @@
-# --perl--
-#
-# vim: syntax=perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/t/TestApp/Action/TicketComment.pm
+++ b/t/TestApp/Action/TicketComment.pm
@@ -1,7 +1,5 @@
 package TestApp::Action::TicketComment;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Action );
 use Log::Log4perl qw( get_logger );

--- a/t/TestApp/Action/TicketCreate.pm
+++ b/t/TestApp/Action/TicketCreate.pm
@@ -1,7 +1,5 @@
 package TestApp::Action::TicketCreate;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Action );
 use File::Spec::Functions qw( catdir );

--- a/t/TestApp/Action/TicketUpdate.pm
+++ b/t/TestApp/Action/TicketUpdate.pm
@@ -1,7 +1,5 @@
 package TestApp::Action::TicketUpdate;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Action );
 use Log::Log4perl qw( get_logger );

--- a/t/TestApp/Condition/AlwaysTrue.pm
+++ b/t/TestApp/Condition/AlwaysTrue.pm
@@ -1,7 +1,5 @@
 package TestApp::Condition::AlwaysTrue;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Condition );
 use Log::Log4perl       qw( get_logger );

--- a/t/TestApp/Condition/HasUserType.pm
+++ b/t/TestApp/Condition/HasUserType.pm
@@ -1,6 +1,6 @@
 package TestApp::Condition::HasUserType;
 
-# $Id: HasUser.pm 290 2007-06-18 21:46:48Z jonasbn $
+
 
 use strict;
 use base qw( Workflow::Condition );

--- a/t/TestApp/User.pm
+++ b/t/TestApp/User.pm
@@ -1,7 +1,5 @@
 package TestApp::User;
 
-# $Id$
-
 use strict;
 
 $TestApp::User::VERSION = '0.01';

--- a/t/TestCachedApp/Condition/EvenCounts.pm
+++ b/t/TestCachedApp/Condition/EvenCounts.pm
@@ -1,7 +1,5 @@
 package TestCachedApp::Condition::EvenCounts;
 
-# $Id$
-
 use strict;
 use base qw( Workflow::Condition );
 use Workflow::Exception qw( condition_error );

--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -1,7 +1,5 @@
 package TestUtil;
 
-# $Id$
-
 use strict;
 use vars qw($VERSION);
 use DateTime;

--- a/t/action.t
+++ b/t/action.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/action.t
+++ b/t/action.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/action_field.t
+++ b/t/action_field.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/action_field.t
+++ b/t/action_field.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/action_mailer.t
+++ b/t/action_mailer.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id: action_null.t 217 2004-12-09 16:02:45Z cwinters $
 

--- a/t/action_mailer.t
+++ b/t/action_mailer.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id: action_null.t 217 2004-12-09 16:02:45Z cwinters $
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/action_null.t
+++ b/t/action_null.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/action_null.t
+++ b/t/action_null.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/action_validate.t
+++ b/t/action_validate.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # Test validation of additional action attributes during parse-time.
 

--- a/t/add_config_bug.t
+++ b/t/add_config_bug.t
@@ -1,7 +1,5 @@
 #!/usr/bin/perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/base.t
+++ b/t/base.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/base.t
+++ b/t/base.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/condition.t
+++ b/t/condition.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/condition.t
+++ b/t/condition.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/condition_evaluate.t
+++ b/t/condition_evaluate.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/condition_evaluate.t
+++ b/t/condition_evaluate.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/config.t
+++ b/t/config.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/config.t
+++ b/t/config.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/context-persists.t
+++ b/t/context-persists.t
@@ -1,4 +1,4 @@
-#! /usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/t/context.t
+++ b/t/context.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/context.t
+++ b/t/context.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/exception.t
+++ b/t/exception.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/exception.t
+++ b/t/exception.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/factory.t
+++ b/t/factory.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/factory.t
+++ b/t/factory.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/factory_callback_config.t
+++ b/t/factory_callback_config.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/factory_callback_config.t
+++ b/t/factory_callback_config.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/factory_subclass.t
+++ b/t/factory_subclass.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/factory_subclass.t
+++ b/t/factory_subclass.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/history.t
+++ b/t/history.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/history.t
+++ b/t/history.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/persister.t
+++ b/t/persister.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id: Persister.t 304 2007-07-03 14:56:43Z jonasbn $
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/persister.t
+++ b/t/persister.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id: Persister.t 304 2007-07-03 14:56:43Z jonasbn $
 

--- a/t/persister_dbi.t
+++ b/t/persister_dbi.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/persister_dbi.t
+++ b/t/persister_dbi.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/persister_dbi_extra_data.t
+++ b/t/persister_dbi_extra_data.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use constant NUM_TESTS => 1;
 use Test::More;

--- a/t/persister_dbi_extra_data.t
+++ b/t/persister_dbi_extra_data.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/persister_dbi_sqlite.t
+++ b/t/persister_dbi_sqlite.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/persister_dbi_sqlite.t
+++ b/t/persister_dbi_sqlite.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 
 use strict;

--- a/t/persister_file.t
+++ b/t/persister_file.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/persister_file.t
+++ b/t/persister_file.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/persister_random_id.t
+++ b/t/persister_random_id.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;
@@ -32,5 +30,3 @@ is( $generator_long->id_length, 36,
 my $id_long = $generator_long->pre_fetch_id;
 is( length( $id_long ), 36,
     'Value returned from generator correct length' );
-
-

--- a/t/persister_random_id.t
+++ b/t/persister_random_id.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/persister_spops.t
+++ b/t/persister_spops.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/persister_spops.t
+++ b/t/persister_spops.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/persister_uuid.t
+++ b/t/persister_uuid.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/persister_uuid.t
+++ b/t/persister_uuid.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/state.t
+++ b/t/state.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/state.t
+++ b/t/state.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/state_perl.t
+++ b/t/state_perl.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 use strict;
 use lib qw(../lib lib ../t t);

--- a/t/validator.t
+++ b/t/validator.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/validator.t
+++ b/t/validator.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/validator_has_required_field.t
+++ b/t/validator_has_required_field.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/validator_has_required_field.t
+++ b/t/validator_has_required_field.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/validator_in_enumerated_type.t
+++ b/t/validator_in_enumerated_type.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/validator_in_enumerated_type.t
+++ b/t/validator_in_enumerated_type.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/validator_matches_date_format.t
+++ b/t/validator_matches_date_format.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/validator_matches_date_format.t
+++ b/t/validator_matches_date_format.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 

--- a/t/workflow.t
+++ b/t/workflow.t
@@ -1,7 +1,5 @@
 #!/usr/bin/env perl
 
-# $Id$
-
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;

--- a/t/workflow.t
+++ b/t/workflow.t
@@ -1,4 +1,4 @@
-# -*-perl-*-
+#!/usr/bin/env perl
 
 # $Id$
 


### PR DESCRIPTION
# Description

1. Removes old SVN/CVS tags scattered throughout the code
1. Alters shebang line to the canonical use of `#!/usr/bin/env perl`

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
