### PR TITLE
Revert "Re #10: Work around bug in Class::Observable observing instances"

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -373,19 +373,6 @@ sub _auto_execute_state {
     }
 }
 
-# This DESTROY method is a work-around for the problem with Class::Observable
-# that when an instance gets allocated in *exactly* the same address as an
-# earlier instance (which has since been destroyed), the observer registration
-# was actually *not* destroyed and the observers are applied to the new
-# instance. See gh issue #10.
-sub DESTROY {
-    my ($self) = @_;
-
-    # ignore all errors: during interpreter shutdown, none of the wrapped
-    # code is expected to work...
-    eval { $self->delete_all_observers() };
-}
-
 1;
 
 __END__


### PR DESCRIPTION
Reverts jonasbn/perl-workflow#60

As pointed out by @ap, this change is no longer necessary, since we implemented the final solution.