### PR TITLE
Rework condition caching to support nested evaluation

### DIFF
--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -4,10 +4,14 @@ use warnings;
 use strict;
 use base qw( Workflow::Base );
 use Carp qw(croak);
+use English qw( -no_match_vars );
+use Log::Log4perl qw( get_logger );
+use Workflow::Exception qw( workflow_error condition_error );
 
 $Workflow::Condition::CACHE_RESULTS = 1;
 $Workflow::Condition::VERSION = '1.52';
 
+my $log;
 my @FIELDS = qw( name class );
 __PACKAGE__->mk_accessors(@FIELDS);
 
@@ -24,6 +28,142 @@ sub evaluate {
     my ($self) = @_;
     croak "Class ", ref($self), " must implement 'evaluate()'!\n";
 }
+
+
+sub evaluate_condition {
+    my ( $class, $wf, $condition_name) = @_;
+    $log ||= get_logger();
+    $wf->type;
+
+    my $factory = $wf->_factory();
+    my $orig_condition = $condition_name;
+    my $opposite       = 0;
+    my $condition;
+
+    $log->is_debug
+        && $log->debug("Checking condition $condition_name");
+
+    if ( $condition_name =~ m{ \A ! }xms ) {
+
+        # this condition starts with a '!' and is thus supposed
+        # to return the opposite of an original condition, whose
+        # name is the same except for the '!'
+        $orig_condition =~ s{ \A ! }{}xms;
+        $opposite = 1;
+        $log->is_debug
+            && $log->debug(
+            "Condition starts with a !: '$condition_name'");
+    }
+
+    local $wf->{'_condition_result_cache'} =
+        $wf->{'_condition_result_cache'} || {};
+    if ( $Workflow::Condition::CACHE_RESULTS
+         && exists $wf->{'_condition_result_cache'}->{$orig_condition} ) {
+
+        # The condition has already been evaluated and the result
+        # has been cached
+        $log->is_debug
+            && $log->debug(
+            "Condition has been cached: '$orig_condition', cached result: ",
+            $wf->{'_condition_result_cache'}->{$orig_condition}
+            );
+        if ( !$opposite ) {
+            $log->is_debug
+                && $log->debug("Opposite is false.");
+            if ( !$wf->{'_condition_result_cache'}->{$orig_condition} )
+            {
+                $log->is_debug
+                    && $log->debug("Cached condition result is false.");
+            }
+            return $wf->{'_condition_result_cache'}->{$orig_condition};
+        } else {
+
+            # we have to return an error if the original cached
+            # condition did NOT fail
+            $log->is_debug
+                && $log->debug("Opposite is true.");
+            if ( $wf->{'_condition_result_cache'}->{$orig_condition} ) {
+                $log->is_debug
+                    && $log->debug("Cached condition is true.");
+                return 0;
+            }
+            return 1;
+        }
+    } else {
+
+        # we did not evaluate the condition yet, we have to do
+        # it now
+        $condition = $wf->_factory()
+            ->get_condition( $orig_condition, $wf->type );
+        $log->is_debug
+            && $log->debug( q{Evaluating condition '},
+                            $condition->name, q{'} );
+        my $return_value;
+        eval { $return_value = $condition->evaluate($wf) };
+        if ($EVAL_ERROR) {
+
+            # Check if this is a Workflow::Exception::Condition
+            if (Exception::Class->caught('Workflow::Exception::Condition')) {
+                # TODO: We may just want to pass the error up
+                # without wrapping it...
+                $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
+                if ( !$opposite ) {
+                    $log->is_debug
+                        && $log->debug("condition '$orig_condition' failed due to: $EVAL_ERROR");
+                    return 0;
+                } else {
+                    $log->is_debug
+                        && $log->debug("opposite condition '$orig_condition' failed due to ' . $EVAL_ERROR");
+                    return 1;
+                }
+                # unreachable
+
+            } else {
+                $log->is_debug
+                    && $log->debug("Got uncatchable exception in condition $condition_name ");
+
+                # if EVAL_ERROR is an execption object rethrow it
+                $EVAL_ERROR->rethrow() if (ref $EVAL_ERROR ne '');
+
+                # if it is a string (bubbled up from die/croak), make an Exception Object
+                # For briefness, we just send back the first line of EVAL
+                my @t = split /\n/, $EVAL_ERROR;
+                my $ee = shift @t;
+
+                Exception::Class::Base->throw( error
+                                               => "Got unknown exception while handling condition '$condition_name' / " . $ee );
+                # unreachable
+
+            }
+            # unreachable
+
+        } else {
+            $wf->{'_condition_result_cache'}->{$orig_condition} = $return_value;
+            if ($opposite) {
+
+                $log->is_debug
+                    && $log->debug(
+                    "condition '$orig_condition' ".
+                    "did NOT fail but opposite requested");
+
+                return 0;
+            } else {
+
+                $log->is_debug &&
+                    $log->debug(
+                        "condition '$orig_condition' succeeded");
+                return $return_value;
+            }
+            # unreachable
+
+        }
+        # unreachable
+
+    }
+    # unreachable
+}
+
+
 
 1;
 
@@ -214,6 +354,30 @@ to zero (0):
 All versions before 1.49 used a mechanism that effectively caused global
 state. To address the problems that resulted (see GitHub issues #9 and #7),
 1.49 switched to a new mechanism with a cache per workflow instance.
+
+
+=head3 $class->evaluate_condition( $WORKFLOW, $CONDITION_NAME )
+
+Users call this method to evaluate a condition; subclasses call this
+method to evaluate a nested condition.
+
+If the condition name starts with an '!', the result of the condition
+is negated. Note that a side-effect of this is that the return
+value of the condition is ignored. Only the negated boolean-ness
+is preserved.
+
+**** TODO **** We need a deprecation warning of some sort! This is
+no longer restricted to nested conditions!
+
+This does implement a trick that is not a convention in the underlying
+Workflow library: by default, workflow conditions throw an error when
+the condition is false and just return when the condition is true. To
+allow for counting the true conditions, we also look at the return
+value here. If a condition returns zero or an undefined value, but
+did not throw an exception, we consider it to be '1'. Otherwise, we
+consider it to be the value returned.
+
+
 
 =head1 COPYRIGHT
 

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -96,8 +96,7 @@ sub evaluate_condition {
         $condition = $wf->_factory()
             ->get_condition( $orig_condition, $wf->type );
         $log->is_debug
-            && $log->debug( q{Evaluating condition '},
-                            $condition->name, q{'} );
+            && $log->debug( "Evaluating condition '$orig_condition'" );
         my $return_value;
         eval { $return_value = $condition->evaluate($wf) };
         if ($EVAL_ERROR) {

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -104,8 +104,6 @@ sub evaluate_condition {
 
             # Check if this is a Workflow::Exception::Condition
             if (Exception::Class->caught('Workflow::Exception::Condition')) {
-                # TODO: We may just want to pass the error up
-                # without wrapping it...
                 $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
                 if ( !$opposite ) {
                     $log->is_debug
@@ -365,9 +363,6 @@ If the condition name starts with an '!', the result of the condition
 is negated. Note that a side-effect of this is that the return
 value of the condition is ignored. Only the negated boolean-ness
 is preserved.
-
-**** TODO **** We need a deprecation warning of some sort! This is
-no longer restricted to nested conditions!
 
 This does implement a trick that is not a convention in the underlying
 Workflow library: by default, workflow conditions throw an error when

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -37,7 +37,7 @@ sub evaluate_condition {
 
     my $factory = $wf->_factory();
     my $orig_condition = $condition_name;
-    my $opposite       = 0;
+    my $negation       = 0;
     my $condition;
 
     $log->is_debug
@@ -46,13 +46,13 @@ sub evaluate_condition {
     if ( $condition_name =~ m{ \A ! }xms ) {
 
         # this condition starts with a '!' and is thus supposed
-        # to return the opposite of an original condition, whose
+        # to return the negation of an original condition, whose
         # name is the same except for the '!'
         $orig_condition =~ s{ \A ! }{}xms;
-        $opposite = 1;
+        $negation = 1;
         $log->is_debug
             && $log->debug(
-            "Condition starts with a !: '$condition_name'");
+            "Condition starts with a ! (negation): '$condition_name'");
     }
 
     local $wf->{'_condition_result_cache'} =
@@ -67,9 +67,9 @@ sub evaluate_condition {
             "Condition has been cached: '$orig_condition', cached result: ",
             $wf->{'_condition_result_cache'}->{$orig_condition}
             );
-        if ( !$opposite ) {
+        if ( !$negation ) {
             $log->is_debug
-                && $log->debug("Opposite is false.");
+                && $log->debug("Negation is false.");
             if ( !$wf->{'_condition_result_cache'}->{$orig_condition} )
             {
                 $log->is_debug
@@ -81,7 +81,7 @@ sub evaluate_condition {
             # we have to return an error if the original cached
             # condition did NOT fail
             $log->is_debug
-                && $log->debug("Opposite is true.");
+                && $log->debug("Negation is true.");
             if ( $wf->{'_condition_result_cache'}->{$orig_condition} ) {
                 $log->is_debug
                     && $log->debug("Cached condition is true.");
@@ -105,13 +105,13 @@ sub evaluate_condition {
             # Check if this is a Workflow::Exception::Condition
             if (Exception::Class->caught('Workflow::Exception::Condition')) {
                 $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
-                if ( !$opposite ) {
+                if ( !$negation ) {
                     $log->is_debug
                         && $log->debug("condition '$orig_condition' failed due to: $EVAL_ERROR");
                     return 0;
                 } else {
                     $log->is_debug
-                        && $log->debug("opposite condition '$orig_condition' failed due to ' . $EVAL_ERROR");
+                        && $log->debug("negated condition '$orig_condition' failed due to ' . $EVAL_ERROR");
                     return 1;
                 }
                 # unreachable
@@ -137,12 +137,12 @@ sub evaluate_condition {
 
         } else {
             $wf->{'_condition_result_cache'}->{$orig_condition} = $return_value;
-            if ($opposite) {
+            if ($negation) {
 
                 $log->is_debug
                     && $log->debug(
                     "condition '$orig_condition' ".
-                    "did NOT fail but opposite requested");
+                    "did NOT fail but negation requested");
 
                 return 0;
             } else {
@@ -336,7 +336,7 @@ change between the two evaluate() calls.
 
 Caching is also used with an inverted condition, which you can specify
 in the definition using C<<condition name="!some_condition">>.
-This condition returns exactly the opposite of the original one, i.e.
+This condition returns the negation of the original one, i.e.
 if the original condition fails, this one does not and the other way
 round. As caching is used, you can model "yes/no" decisions using this
 feature - if you have both C<<condition name="some_condition">> and

--- a/lib/Workflow/Condition/Nested.pm
+++ b/lib/Workflow/Condition/Nested.pm
@@ -6,84 +6,6 @@ use warnings;
 our $VERSION = '1.52';
 
 use base qw( Workflow::Condition );
-use Workflow::Factory qw( FACTORY );
-use English qw( -no_match_vars );
-use Log::Log4perl qw( get_logger );
-use Exception::Class;
-
-
-sub evaluate_condition {
-    my ( $self, $wf, $condition_name ) = @_;
-
-    my $factory;
-    if ( $wf->can('_factory') ) {
-        $factory = $wf->_factory();
-    } else {
-        $factory = FACTORY;
-    }
-
-    my $condition;
-
-    my $orig_condition = $condition_name;
-    my $opposite       = 0;
-
-    $self->log->is_debug
-        && $self->log->debug("Checking condition $condition_name");
-
-    if ( $condition_name =~ m{ \A ! }xms ) {
-
-        $orig_condition =~ s{ \A ! }{}xms;
-        $opposite = 1;
-        $self->log->is_debug
-            && $self->log->debug("Condition starts with a !: '$condition_name'");
-    }
-
-    # NOTE: CACHING IS NOT IMPLEMENTED/TESTED YET
-
-    $condition = $factory->get_condition( $orig_condition, $wf->type() );
-
-    my $result;
-    $self->log->is_debug
-        && $self->log->debug( q{Evaluating condition '}, $condition->name, q{'} );
-    eval { $result = $condition->evaluate($wf) };
-    if ($EVAL_ERROR) {
-
-        # Only stop on workflow_condition errors and bubble up anything else
-        if (!Exception::Class->caught('Workflow::Exception::Condition')) {
-            # We can use die here as it will be caught by the outer condition
-            (ref $EVAL_ERROR ne '') ? $EVAL_ERROR->rethrow() : die $EVAL_ERROR;
-        }
-
-        # TODO: We may just want to pass the error up without wrapping it...
-        $factory->{'_condition_result_cache'}->{$orig_condition} = 0;
-        if ( !$opposite ) {
-            $self->log->is_debug
-                && $self->log->debug("Condition '$condition_name' failed");
-            return 0;
-        } else {
-            $self->log->is_debug
-                && $self->log->debug(
-                "Condition '$condition_name' failed, but result is negated");
-            return 1;
-        }
-    } else {
-        $factory->{'_condition_result_cache'}->{$orig_condition} = $result
-            || 1;
-        if ($opposite) {
-            $self->log->is_debug
-                && $self->log->debug(
-                "Condition '$condition_name' OK, but result is negated");
-            return 0;
-        } else {
-            $self->log->is_debug
-                && $self->log->debug(
-                " Condition '$condition_name' OK and not negated");
-
-            # If the condition returned nothing, bump it to 1
-            return $result || 1;
-        }
-    }
-}
 
 1;
 
@@ -117,7 +39,8 @@ return the total number of successes. The result is then checked against
 the number needed, returning the boolean value needed by Workflow::State.
 
 B<Note:> This class is not used directly, but subclassed by your class
-that implements the C<evaluate()> method and calls methods declared here.
+that implements the C<evaluate()> method and calls the C<evaluate_condition>
+method to evaluate its nested conditions.
 
 =head1 SYNOPSIS
 
@@ -157,28 +80,9 @@ In workflow.xml:
 
 =cut
 
-=head1 IMPLEMENTATION DETAILS
+=head1 AUTHORS
 
-This wicked hack runs the condition half-outside of the Workflow framework.
-If the Workflow internals change, this may break.
-
-=head2 $self->evaluate_condition( $WORKFLOW, $CONDITION_NAME )
-
-The child object class that subclasses this object calls
-this method to evaluate a nested condition.
-
-If the condition name starts with an '!', the result of the condition
-is negated. Note that a side-effect of this is that the return
-value of the nested condition is ignored. Only the negated boolean-ness
-is preserved.
-
-This does implement a trick that is not a convention in the underlying
-Workflow library. By default, workflow conditions throw an error when
-the condition is false and just return when the condition is true. To
-allow for counting the true conditions, we also look at the return
-value here. If a condition returns zero or an undefined value, but
-did not throw an exception, we consider it to be '1'. Otherwise, we
-consider it to be the value returned.
+See L<Workflow>
 
 =head1 COPYRIGHT
 

--- a/t/05_condition_nested.t
+++ b/t/05_condition_nested.t
@@ -6,8 +6,10 @@ use lib qw(../lib lib ../t t);
 
 use Test::More;
 
+
 require Workflow::Factory;
 require Workflow::Persister::DBI;
+
 
 my $debug = $ENV{TEST_DEBUG};
 
@@ -24,6 +26,10 @@ if ($debug) {
         unlink($LOG_FILE);
     }
     Log::Log4perl::init($CONF_FILE);
+}
+else {
+    no warnings 'once';
+    Log::Log4perl::easy_init($Log::Log4perl::OFF);
 }
 
 plan tests => 26;
@@ -71,6 +77,8 @@ is( $workflow->state, 'INITIALIZED', 'initialized state' );
 #diag( "Available actions: " . join(', ', $workflow->get_current_actions));
 $workflow->execute_action('test_greedy_or');
 is( $workflow->state, 'TEST_GREEDY_OR', 'wfcond state after test_greedy_or' );
+
+Log::Log4perl::get_logger()->error('START OFFENDING TEST');
 $workflow->execute_action('greedy_or_1');
 is( $workflow->state, 'INITIALIZED', 'wfcond state after greedy_or_1' )
     or $workflow->execute_action('ack_subtest_fail');

--- a/t/TestCachedApp/Condition/EvenCounts.pm
+++ b/t/TestCachedApp/Condition/EvenCounts.pm
@@ -2,15 +2,27 @@ package TestCachedApp::Condition::EvenCounts;
 
 use strict;
 use base qw( Workflow::Condition );
+
+use Log::Log4perl qw(get_logger);
+
 use Workflow::Exception qw( condition_error );
+
+my $log = get_logger();
 
 our $count = 0;
 
 sub evaluate {
     my ( $self, $wf ) = @_;
-    if ($count++ % 2 == 1) {
+    $log->debug(__PACKAGE__, '::evaluate(', $count, ')');
+    if ((($count++) >> 1) % 2 == 0) {
+        # the condition is a bit tricky here:
+        #  because the condition is evaluated twice, we need to return
+        #  the same result twice: the first time on 'get_current_actions'
+        #  and the second time on 'execute_action'
+        $log->debug(__PACKAGE__, '::evaluate(', $count, '): fail');
         condition_error "Current count is not divisible by 2";
     }
+    $log->debug(__PACKAGE__, '::evaluate(', $count, '): success');
 }
 
 1;

--- a/t/cached_conditions.t
+++ b/t/cached_conditions.t
@@ -19,13 +19,14 @@ my $wf = $factory->create_workflow( 'CachedCondition' );
 my $does_change;
 
 my @actions = $wf->get_current_actions();
-is(scalar @actions, 2, 'Exactly two actions available');
+is(scalar @actions, 2, 'Exactly two actions available')
+     or diag "got these:  @actions";
 my $old_actions = join q{, }, sort @actions;
 
 CHECK_TIME_CHANGE:
-for (my $i = 0; $i < 5; $i++) {
+for (my $i = 0; $i < 10; $i++) {
     my $curr_actions = join q{, }, sort ( $wf->get_current_actions() );
-    # diag $curr_actions;
+    #    diag "check_change: $curr_actions";
     if ($old_actions ne $curr_actions) {
         # the current action is not the one from before, this is good
         # as we need to recheck the conditions everytime someone wants
@@ -40,14 +41,14 @@ ok($does_change, 'Available actions change over time');
 
 $does_change = 0;
 CHECK_STATE_CHANGE:
-for (my $i = 0; $i < 5; $i++) {
+for (my $i = 0; $i < 10; $i++) {
     # execute a null action to go to the second state
     $wf->execute_action('FORWARD');
     # and go back again
     $wf->execute_action('BACK');
 
     my $curr_actions = join q{, }, sort ( $wf->get_current_actions() );
-    # diag $curr_actions;
+    #    diag "check_state: $curr_actions";
     if ($old_actions ne $curr_actions) {
         # the current action is not the one from before, this is good
         # as we need to recheck the conditions everytime someone wants
@@ -62,7 +63,8 @@ ok($does_change, 'Available actions change when changing states');
 is( $wf->state, 'INITIAL', 'workflow is in INITIAL state' );
 my $actions = join( ', ', sort $wf->get_current_actions() );
 ok( ( $actions =~ m/FORWARD,/ ) ,
-    'FORWARD action is available in workflow' );
+    'FORWARD action is available in workflow' )
+    or diag $actions;
 $wf->context->param( alternative => 'yes' );
 $actions = join( ', ', sort $wf->get_current_actions() );
 ok( ( $actions =~ m/FORWARD-ALT,/ ) ,


### PR DESCRIPTION
# Description

Prior to this change, only top-level condition outcomes were cached;
however, use of conditions isn't restricted to the top level, yet
with caching one would expect exactly a single condition evaluation
per block of cached conditions.

Note: this change is created for the purpose of discussion and therefor marked as Draft.

## Type of change

I'm not sure if this is a bug fix or a new feature: we were supposed to have a condition cache, but nested condition evaluations weren't cached at all... (Which, given the lack of issues registered about this situation since its creation -- some 17 years ago -- might be an over-engineered function?)

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

