### PR TITLE
Removed Module::Build addressing issue #93

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -59,10 +59,6 @@ fail_on_warning = none
 ; REF: Dist::Zilla::Plugin::Test::CPAN::Meta::JSON: https://metacpan.org/pod/Dist::Zilla::Plugin::Test::CPAN::Meta::JSON
 [Test::CPAN::Meta::JSON]
 
-; REF: Dist::Zilla::Plugin::ModuleBuild: https://metacpan.org/pod/Dist::Zilla::Plugin::ModuleBuild
-[ModuleBuild]
-mb_version = 0.30
-
 ; REF: Dist::Zilla::Plugin::MetaProvides::Package : https://metacpan.org/pod/Dist::Zilla::Plugin::MetaProvides::Package
 [MetaProvides::Package]
 inherit_version = 0    ;optional flag


### PR DESCRIPTION
# Description

As outlined in the blog post referenced in issue #93 it is not recommended to support both Module::Build and ExtUtils::MakeMaker.

Since the latter is core and Module::Build no longer is, this PR proposes eliminating Module::Build and sticking to only supporting ExtUtils::MakeMaker

closes #93 

- [X] This change requires a documentation update

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
