### PR TITLE
Suppressing of useless log message

### DIFF
--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -259,9 +259,13 @@ sub _add_workflow_config {
             push @{ $self->{_workflow_state}{$wf_type} }, $wf_state;
         }
 
+        $self->_load_observers($workflow_config);
+
         $log->is_info
             && $log->info("Added all workflow states...");
     }
+
+    return;
 }
 
 # Load all the observers so they're available when we instantiate the
@@ -1049,6 +1053,12 @@ to a workflow in L<create_workflow()|/create_workflow> and
 L<fetch_workflow()|/fetch_workflow>.
 
 Returns: nothing
+
+=head3 _load_observers( $workflow_config_hashref )
+
+Loads and adds observers based on workflow type
+
+Returns number indicating amount of observers added, meaning zero can indicate success based on expected outcome.
 
 =head3 _add_action_config( @config_hashrefs )
 

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -261,10 +261,6 @@ sub _add_workflow_config {
 
         $log->is_info
             && $log->info("Added all workflow states...");
-
-        my $num_observers = $self->_load_observers($workflow_config);
-        $log->is_info
-            && $log->info("Added $num_observers workflow observers...");
     }
 }
 
@@ -304,18 +300,23 @@ sub _load_observers {
                 "Workflow::Factory docs for details.)";
         }
     }
-    # FIXME: is logged even though no observers are added
-    if (scalar @observers) {
-        $log->is_info
-            && $log->info( "Added observers to '$wf_type': ", join ', ', @observers );
 
+    my $observers_num = scalar @observers;
+
+    if (@observers) {
         $self->{_workflow_observers}{$wf_type} = \@observers;
+
+        $log->is_info
+            && $log->info( "Added $observers_num to '$wf_type': ", join ', ', @observers );
 
     } else {
         $self->{_workflow_observers}{$wf_type} = undef;
 
+        $log->is_info
+            && $log->info( "No observers added to '$wf_type'" );
     }
-    return scalar @observers;
+
+    return $observers_num;
 }
 
 sub _load_class {

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -262,9 +262,9 @@ sub _add_workflow_config {
         $log->is_info
             && $log->info("Added all workflow states...");
 
-        $self->_load_observers($workflow_config);
+        my $num_observers = $self->_load_observers($workflow_config);
         $log->is_info
-            && $log->info("Added all workflow observers...");
+            && $log->info("Added $num_observers workflow observers...");
     }
 }
 
@@ -304,11 +304,18 @@ sub _load_observers {
                 "Workflow::Factory docs for details.)";
         }
     }
-    $log->is_info
-        && $log->info( "Added observers to '$wf_type': ", join ', ',
-        @observers );
-    $self->{_workflow_observers}{$wf_type}
-        = scalar @observers ? \@observers : undef;
+    # FIXME: is logged even though no observers are added
+    if (scalar @observers) {
+        $log->is_info
+            && $log->info( "Added observers to '$wf_type': ", join ', ', @observers );
+
+        $self->{_workflow_observers}{$wf_type} = \@observers;
+
+    } else {
+        $self->{_workflow_observers}{$wf_type} = undef;
+
+    }
+    return scalar @observers;
 }
 
 sub _load_class {


### PR DESCRIPTION
Suppressed log message indicating addition of observers when none where defined. Altered log messages to report number of added observers even if zero added for more exact reporting.

I am unsure as to whether enabling return values is a good idea, well I think it is, but I need a reviewer perspective.

In case we do this, documentation would require an update

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
