### PR TITLE
Re #68: Reduce chatty logging for 'condition_error' and 'validation_error'

### DIFF
--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -44,7 +44,6 @@ sub evaluate {
     $safe->share('$context');
     my $rv = $safe->reval($to_eval);
     if ($EVAL_ERROR) {
-        $self->log->error("Eval code '$to_eval' threw exception: $EVAL_ERROR");
         condition_error
             "Condition expressed in code threw exception: $EVAL_ERROR";
     }

--- a/lib/Workflow/Exception.pm
+++ b/lib/Workflow/Exception.pm
@@ -26,6 +26,7 @@ use Exception::Class (
 );
 
 use Log::Log4perl qw( get_logger );
+use Log::Log4perl::Level;
 
 my %TYPE_CLASSES = (
     condition_error     => 'Workflow::Exception::Condition',
@@ -34,6 +35,14 @@ my %TYPE_CLASSES = (
     validation_error    => 'Workflow::Exception::Validation',
     workflow_error      => 'Workflow::Exception',
 );
+my %TYPE_LOGGING = (
+    condition_error     => $TRACE,
+    configuration_error => $ERROR,
+    persist_error       => $ERROR,
+    validation_error    => $INFO,
+    workflow_error      => $ERROR,
+);
+
 
 $Workflow::Exception::VERSION   = '1.52';
 @Workflow::Exception::ISA       = qw( Exporter Exception::Class::Base );
@@ -51,10 +60,9 @@ sub _mythrow {
     my ( $prev_pkg, $prev_line ) = ( caller 1 )[ 0, 2 ];
 
     # Do not log condition errors
-    if ($type ne 'condition_error') {
-        $log->error( "$type exception thrown from [$pkg: $line; before: ",
-            "$prev_pkg: $prev_line]: $msg" );
-    }
+    $log->log( $TYPE_LOGGING{$type},
+               "$type exception thrown from [$pkg: $line; before: ",
+               "$prev_pkg: $prev_line]: $msg" );
 
     goto &Exception::Class::Base::throw(
         $TYPE_CLASSES{$type},

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -183,7 +183,7 @@ sub evaluate_action {
                     $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
                     if ( !$opposite ) {
                         condition_error "No access to action '$action_name' in ",
-                            "state '$state'; condition '$orig_condition' failed because: $EVAL_ERROR";
+                            "state '$state'; condition '$orig_condition' failed due to: $EVAL_ERROR";
                     } else {
                         $self->log->is_debug
                             && $self->log->debug("opposite condition '$orig_condition' failed because ' . $EVAL_ERROR");

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -182,12 +182,8 @@ sub evaluate_action {
                     # without wrapping it...
                     $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
                     if ( !$opposite ) {
-                        $self->log->is_debug
-                            && $self->log->debug("No access to action '$action_name', condition " .
-                             "'$orig_condition' failed because ' . $EVAL_ERROR");
-
                         condition_error "No access to action '$action_name' in ",
-                            "state '$state' because: $EVAL_ERROR";
+                            "state '$state'; condition '$orig_condition' failed because: $EVAL_ERROR";
                     } else {
                         $self->log->is_debug
                             && $self->log->debug("opposite condition '$orig_condition' failed because ' . $EVAL_ERROR");
@@ -209,12 +205,6 @@ sub evaluate_action {
             } else {
                 $wf->{'_condition_result_cache'}->{$orig_condition} = 1;
                 if ($opposite) {
-
-                    $self->log->is_debug
-                        && $self->log->debug(
-                            "No access to action '$action_name', condition '$orig_condition' ".
-                            "did NOT failed but opposite requested");
-
                     condition_error "No access to action '$action_name' in ",
                         "state '$state' because condition ",
                         "$orig_condition did NOT fail and we ",

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -186,7 +186,7 @@ sub evaluate_action {
                             "state '$state'; condition '$orig_condition' failed due to: $EVAL_ERROR";
                     } else {
                         $self->log->is_debug
-                            && $self->log->debug("opposite condition '$orig_condition' failed because ' . $EVAL_ERROR");
+                            && $self->log->debug("opposite condition '$orig_condition' failed due to ' . $EVAL_ERROR");
                     }
                 } else {
                     $self->log->is_debug


### PR DESCRIPTION
# Description

As per @oliwel's request, change the logging of the validator's "error"
to DEBUG level: it's not really an error, it's a failure of the user to
provide compliant input (which is at *most* an informational message).

At the same time, add logging of condition errors as a TRACE level
message: these are not failures by any measure; they are merely
conditions evaluating to 'false'. When debugging, it might be handy
to be able to check these, but usually this is too chatty for debugging.
Putting the logging in TRACE instead.

At the same time, remove duplicate logging of condition validation results
which go both through direct logging as well as through logging of `condition_error`s.

Addresses some of #68

## Type of change

Improvement of existing feature.

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

