### PR TITLE
Remove newline characters from logging

### DIFF
--- a/lib/Workflow/Exception.pm
+++ b/lib/Workflow/Exception.pm
@@ -105,6 +105,7 @@ sub _massage {
 
     my %params = ( ref $items[-1] eq 'HASH' ) ? %{ pop @items } : ();
     my $msg = join '', @items;
+    $msg =~ s/\\n/ /g; # don't log newlines as per Log4perl recommendations
     return ( $msg, %params );
 }
 

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -555,8 +555,10 @@ sub _add_action_config {
                 "Trying to include action class '$action_class'...");
             eval "require $action_class";
             if ($EVAL_ERROR) {
+                my $msg = $EVAL_ERROR;
+                $msg =~ s/\\n/ /g;
                 configuration_error
-                    "Cannot include action class '$action_class': $EVAL_ERROR";
+                    "Cannot include action class '$action_class': $msg";
             }
             $self->log->is_debug
                 && $self->log->debug(

--- a/lib/Workflow/Persister.pm
+++ b/lib/Workflow/Persister.pm
@@ -55,7 +55,10 @@ sub init_random_generators {
     my ( $self, $params ) = @_;
     my $length = $params->{id_length} || DEFAULT_ID_LENGTH;
     eval { require Workflow::Persister::RandomId };
-    $self->log->error($EVAL_ERROR) if $EVAL_ERROR;
+    if (my $msg = $EVAL_ERROR) {
+        $msg =~ s/\\n/ /g;
+        $self->log->error($msg);
+    }
     my $generator
         = Workflow::Persister::RandomId->new( { id_length => $length } );
     return ( $generator, $generator );
@@ -65,7 +68,10 @@ sub init_uuid_generators {
     my ( $self, $params ) = @_;
 
     eval { require Workflow::Persister::UUID };
-    $self->log->error($EVAL_ERROR) if $EVAL_ERROR;
+    if (my $msg = $EVAL_ERROR) {
+        $msg =~ s/\\n/ /g;
+        $self->log->error($msg);
+    }
     my $generator = Workflow::Persister::UUID->new();
     return ( $generator, $generator );
 }

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -216,8 +216,8 @@ sub create_workflow {
         join( ', ', map {'?'} @values );
 
     if ( $self->log->is_debug ) {
-        $self->log->debug("Will use SQL\n$sql");
-        $self->log->debug( "Will use parameters\n", join ', ', @values );
+        $self->log->debug("Will use SQL: $sql");
+        $self->log->debug( "Will use parameters: ", join ', ', @values );
     }
 
     my ($sth);
@@ -244,11 +244,7 @@ sub create_workflow {
 sub fetch_workflow {
     my ( $self, $wf_id ) = @_;
     $self->_init_fields();
-    my $sql = q{
-        SELECT %s, %s
-          FROM %s
-         WHERE %s = ?
-    };
+    my $sql = q{SELECT %s, %s FROM %s WHERE %s = ?};
     my @wf_fields = @{ $self->_wf_fields };
     $sql = sprintf $sql,
         $wf_fields[2], $wf_fields[3],
@@ -256,7 +252,7 @@ sub fetch_workflow {
         $wf_fields[0];
 
     if ( $self->log->is_debug ) {
-        $self->log->debug("Will use SQL\n$sql");
+        $self->log->debug("Will use SQL: $sql");
         $self->log->debug("Will use parameters: $wf_id");
     }
 
@@ -280,12 +276,7 @@ sub fetch_workflow {
 sub update_workflow {
     my ( $self, $wf ) = @_;
     $self->_init_fields();
-    my $sql = q{
-        UPDATE %s
-           SET %s = ?,
-               %s = ?
-         WHERE %s = ?
-    };
+    my $sql = q{UPDATE %s SET %s = ?, %s = ? WHERE %s = ?};
     my @wf_fields = @{ $self->_wf_fields };
     $sql          = sprintf $sql,
         $self->handle->quote_identifier( $self->workflow_table ),
@@ -294,8 +285,8 @@ sub update_workflow {
         ->strftime( $self->date_format() );
 
     if ( $self->log->is_debug ) {
-        $self->log->debug("Will use SQL\n$sql");
-        $self->log->debug( "Will use parameters\n",
+        $self->log->debug("Will use SQL: $sql");
+        $self->log->debug( "Will use parameters: ",
             join ', ', $wf->state, $update_date, $wf->id );
     }
 
@@ -334,8 +325,8 @@ sub create_history {
         $sql = sprintf $sql, $dbh->quote_identifier( $self->history_table ),
             join( ', ', @fields ), join( ', ', map {'?'} @values );
         if ( $self->log->is_debug ) {
-            $self->log->debug("Will use SQL\n$sql");
-            $self->log->debug( "Will use parameters\n", join ', ', @values );
+            $self->log->debug("Will use SQL: $sql");
+            $self->log->debug( "Will use parameters: ", join ', ', @values );
         }
 
         my ($sth);
@@ -364,12 +355,7 @@ sub fetch_history {
     my ( $self, $wf ) = @_;
     $self->_init_fields();
 
-    my $sql = qq{
-        SELECT %s
-          FROM %s
-         WHERE %s = ?
-      ORDER BY %s DESC
-    };
+    my $sql = qq{SELECT %s FROM %s WHERE %s = ? ORDER BY %s DESC};
     my @hist_fields    = @{ $self->_hist_fields };
     my $history_fields = join ', ', @hist_fields;
     $sql = sprintf $sql, $history_fields,
@@ -377,7 +363,7 @@ sub fetch_history {
         $hist_fields[1], $hist_fields[6];
 
     if ( $self->log->is_debug ) {
-        $self->log->debug("Will use SQL\n$sql");
+        $self->log->debug("Will use SQL: $sql");
         $self->log->debug( "Will use parameters: ", $wf->id );
     }
 

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -52,10 +52,7 @@ sub fetch_extra_workflow_data {
     $self->log->is_debug
         && $self->log->debug( "Fetching extra workflow data for '", $wf->id, "'" );
 
-    my $sql = q{
-       SELECT %s FROM %s
-        WHERE workflow_id = ?
-    };
+    my $sql = q{SELECT %s FROM %s WHERE workflow_id = ?};
     my $data_field = $self->data_field;
     my $select_data_fields
         = ( ref $data_field )
@@ -65,7 +62,7 @@ sub fetch_extra_workflow_data {
     $sql = sprintf $sql, $select_data_fields,
         $self->handle->quote_identifier( $self->table );
     $self->log->is_debug
-        && $self->log->debug("Using SQL\n$sql");
+        && $self->log->debug("Using SQL: $sql");
     $self->log->is_debug
         && $self->log->debug( "Bind parameters: ", $wf->id );
 


### PR DESCRIPTION
# Description

Remove newline characters from logging; Log::Log4per recommends to log without newlines because it breaks log parsers (espeically when one log message per line is expected).

Or, when logged messages contain new line characters, replace them with a
lowercase letter N preceeded by double backslashes.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
