### PR TITLE
Simplify logging by removing `is_*` logging level checks before logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
         run: |
           cd build
           cpanm --installdeps --local-lib ${GITHUB_WORKSPACE}/local --with-all-features --with-develop --with-suggests .
-      - name: Install
-        run: cpanm Devel::Cover::Report::Coveralls
       - name: Run tests
         run: |
           cd build

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -70,8 +70,7 @@ sub context {
 
 sub get_current_actions {
     my ( $self, $group ) = @_;
-    $self->log->is_debug
-        && $self->log->debug( "Getting current actions for wf '", $self->id, "'" );
+    $self->log->debug( "Getting current actions for wf '", $self->id, "'" );
     my $wf_state = $self->_get_workflow_state;
     return $wf_state->get_available_action_names( $self, $group );
 }
@@ -121,9 +120,9 @@ sub execute_action {
 
     eval {
         $action->validate($self);
-        $self->log->is_debug && $self->log->debug("Action validated ok");
+        $self->log->debug("Action validated ok");
         $action_return = $action->execute($self);
-        $self->log->is_debug && $self->log->debug("Action executed ok");
+        $self->log->debug("Action executed ok");
 
         $new_state = $self->_get_next_state( $action_name, $action_return );
         if ( $new_state ne NO_CHANGE_VALUE ) {
@@ -147,8 +146,7 @@ sub execute_action {
         # If using a DBI persister with no autocommit, commit here.
         $self->_factory()->_commit_transaction($self);
 
-        $self->log->is_info
-            && $self->log->info("Saved workflow with possible new state ok");
+        $self->log->info("Saved workflow with possible new state ok");
     };
 
     # If there's an exception, reset the state to the original one and
@@ -206,11 +204,11 @@ sub add_history {
             $item->{workflow_id} = $self->id;
             $item->{time_zone}   = $self->time_zone();
             push @to_add, Workflow::History->new($item);
-            $self->log->is_debug && $self->log->debug("Adding history from hashref");
+            $self->log->debug("Adding history from hashref");
         } elsif ( ref $item and $item->isa('Workflow::History') ) {
             $item->workflow_id( $self->id );
             push @to_add, $item;
-            $self->log->is_debug && $self->log->debug("Adding history object directly");
+            $self->log->debug("Adding history object directly");
         } else {
             workflow_error "I don't know how to add a history of ", "type '",
                 ref($item), "'";

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -79,8 +79,7 @@ sub get_action {
     my ( $self, $action_name ) = @_;
 
     my $state = $self->state;
-    $self->log->is_debug
-        && $self->log->debug(
+    $self->log->debug(
         "Trying to find action '$action_name' in state '$state'");
 
     my $wf_state = $self->_get_workflow_state;
@@ -88,8 +87,7 @@ sub get_action {
         workflow_error
             "State '$state' does not contain action '$action_name'";
     }
-    $self->log->is_debug
-        && $self->log->debug("Action '$action_name' exists in state '$state'");
+    $self->log->debug("Action '$action_name' exists in state '$state'");
 
     my $action = $self->_get_workflow_state()->get_action( $self, $action_name );
 
@@ -126,9 +124,7 @@ sub execute_action {
 
         $new_state = $self->_get_next_state( $action_name, $action_return );
         if ( $new_state ne NO_CHANGE_VALUE ) {
-            $self->log->is_info
-                && $self->log->info(
-                "Set new state '$new_state' after action executed");
+            $self->log->info("Set new state '$new_state' after action executed");
             $self->state($new_state);
         }
 
@@ -185,8 +181,7 @@ sub execute_action {
     }
 
     if ( $new_state_obj->autorun ) {
-        $self->log->is_info
-            && $self->log->info(
+        $self->log->info(
             "State '$new_state' marked to be run ",
             "automatically; executing that state/action..."
             );
@@ -282,8 +277,7 @@ sub init {
     while ( my ( $key, $value ) = each %{$config} ) {
         next if ( $key =~ /^(type|description)$/ );
         next if ( ref $value );
-        $self->log->is_debug
-            && $self->log->debug("Assigning parameter '$key' -> '$value'");
+        $self->log->debug("Assigning parameter '$key' -> '$value'");
         $self->param( $key, $value );
     }
 
@@ -317,8 +311,7 @@ sub _get_workflow_state {
     my ( $self, $state ) = @_;
     $state ||= '';             # get rid of -w...
     my $use_state = $state || $self->state;
-    $self->log->is_debug
-        && $self->log->debug(
+    $self->log->debug(
         "Finding Workflow::State object for state [given: $use_state] ",
         "[internal: ", $self->state, "]" );
     my $wf_state = $self->{_states}{$use_state};
@@ -355,8 +348,7 @@ sub _auto_execute_state {
             $error->rethrow();
         }
     } else {    # everything is fine, execute action
-        $self->log->is_debug
-            && $self->log->debug(
+        $self->log->debug(
             "Found action '$action_name' to execute in ",
             "autorun state ",
             $wf_state->state

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -39,8 +39,7 @@ sub evaluate_condition {
     my $orig_condition = $condition_name;
     my $condition;
 
-    $log->is_debug
-        && $log->debug("Checking condition $condition_name");
+    $log->debug("Checking condition $condition_name");
 
     local $wf->{'_condition_result_cache'} =
         $wf->{'_condition_result_cache'} || {};
@@ -50,8 +49,7 @@ sub evaluate_condition {
         my $cache_value = $wf->{'_condition_result_cache'}->{$orig_condition};
         # The condition has already been evaluated and the result
         # has been cached
-        $log->is_debug
-            && $log->debug(
+        $log->debug(
             "Condition has been cached: '$orig_condition', cached result: ",
             $cache_value || ''
             );
@@ -63,8 +61,7 @@ sub evaluate_condition {
         # it now
         $condition = $wf->_factory()
             ->get_condition( $orig_condition, $wf->type );
-        $log->is_debug
-            && $log->debug( "Evaluating condition '$orig_condition'" );
+        $log->debug( "Evaluating condition '$orig_condition'" );
         my $return_value;
         eval { $return_value = $condition->evaluate($wf) };
         if ($EVAL_ERROR) {
@@ -72,14 +69,13 @@ sub evaluate_condition {
             # Check if this is a Workflow::Exception::Condition
             if (Exception::Class->caught('Workflow::Exception::Condition')) {
                 $wf->{'_condition_result_cache'}->{$orig_condition} = 0;
-                $log->is_debug
-                    && $log->debug("condition '$orig_condition' failed due to: $EVAL_ERROR");
+                $log->debug(
+                    "condition '$orig_condition' failed due to: $EVAL_ERROR");
                 return 0;
                 # unreachable
 
             } else {
-                $log->is_debug
-                    && $log->debug("Got uncatchable exception in condition $condition_name ");
+                $log->debug("Got uncatchable exception in condition $condition_name ");
 
                 # if EVAL_ERROR is an execption object rethrow it
                 $EVAL_ERROR->rethrow() if (ref $EVAL_ERROR ne '');
@@ -98,9 +94,7 @@ sub evaluate_condition {
 
         } else {
             $wf->{'_condition_result_cache'}->{$orig_condition} = $return_value;
-            $log->is_debug &&
-                $log->debug(
-                    "condition '$orig_condition' succeeded");
+            $log->debug("condition '$orig_condition' succeeded");
             return $return_value;
         }
         # unreachable

--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -48,10 +48,9 @@ sub evaluate {
             "Condition expressed in code threw exception: $EVAL_ERROR";
     }
 
-    $self->log->is_debug
-        && $self->log->debug( "Safe eval ran ok, returned: '"
-            . ( defined $rv ? $rv : '<undef>' )
-            . "'" );
+    $self->log->debug( "Safe eval ran ok, returned: '",
+                       ( defined $rv ? $rv : '<undef>' ),
+                       "'" );
     unless ($rv) {
         condition_error "Condition expressed by test '$to_eval' did not ",
             "return a true value.";

--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -24,16 +24,14 @@ sub _init {
         configuration_error
             "The evaluate condition must be configured with 'test'";
     }
-    $self->log->is_info
-        && $self->log->info("Added evaluation condition with '$params->{test}'");
+    $self->log->info("Added evaluation condition with '$params->{test}'");
 }
 
 sub evaluate {
     my ( $self, $wf ) = @_;
 
     my $to_eval = $self->test;
-    $self->log->is_info
-        && $self->log->info("Evaluating '$to_eval' to see if it returns true...");
+    $self->log->info("Evaluating '$to_eval' to see if it returns true...");
 
     # Assign our local stuff to package variables...
     $Workflow::Condition::Evaluate::context = $wf->context->param;

--- a/lib/Workflow/Condition/HasUser.pm
+++ b/lib/Workflow/Condition/HasUser.pm
@@ -18,8 +18,7 @@ sub _init {
 
 sub evaluate {
     my ( $self, $wf ) = @_;
-    $self->log->is_debug
-        && $self->log->debug( "Trying to execute condition ", ref $self );
+    $self->log->debug( "Trying to execute condition ", ref $self );
     my $user_key     = $self->param('user_key');
     my $current_user = $wf->context->param($user_key);
     $self->log->debug( "Current user in the context is '$current_user' retrieved ",

--- a/lib/Workflow/Config/Perl.pm
+++ b/lib/Workflow/Config/Perl.pm
@@ -36,14 +36,12 @@ sub parse {
             $method    = '_translate_perl_file';
             $file_name = $item;
         }
-        $log->is_info
-            && $log->info("Will parse '$type' Perl config file '$file_name'");
+        $log->info("Will parse '$type' Perl config file '$file_name'");
         my $this_config = $self->$method( $type, $item );
 
         #warn "This config looks like:";
         #warn Dumper (\$this_config);
-        $log->is_info
-            && $log->info("Parsed Perl '$file_name' ok");
+        $log->info("Parsed Perl '$file_name' ok");
 
         if ( exists $this_config->{'type'} ) {
             $log->debug("Adding typed configuration for '$type'");
@@ -77,8 +75,7 @@ sub _translate_perl_file {
     my $config = <CONF>;
     close(CONF) || configuration_error "Cannot close file '$file': $!";
     my $data = $class->_translate_perl( $type, $config, $file );
-    $log->is_debug
-        && $log->debug( "Translated '$type' '$file' into: ", Dumper($data) );
+    $log->debug( sub { "Translated '$type' '$file' into: ", Dumper($data) } );
     return $data;
 }
 

--- a/lib/Workflow/Config/XML.pm
+++ b/lib/Workflow/Config/XML.pm
@@ -53,27 +53,23 @@ sub parse {
     my @config = ();
     foreach my $item (@config_items) {
         my $file_name = ( ref $item ) ? '[scalar ref]' : $item;
-        $log->is_info
-            && $log->info("Will parse '$type' XML config file '$file_name'");
+        $log->info("Will parse '$type' XML config file '$file_name'");
         my $this_config;
         eval { $this_config = $self->_translate_xml( $type, $item ); };
 
         # If processing multiple config files, this makes it much easier
         # to find a problem.
         croak "Processing $file_name: $EVAL_ERROR" if $EVAL_ERROR;
-        $log->is_info
-            && $log->info("Parsed XML '$file_name' ok");
+        $log->info("Parsed XML '$file_name' ok");
 
         # This sets the outer-most tag to use
         # when returning the parsed XML.
         my $outer_tag = $self->get_config_type_tag($type);
         if ( ref $this_config->{$outer_tag} eq 'ARRAY' ) {
-            $log->is_debug
-                && $log->debug("Adding multiple configurations for '$type'");
+            $log->debug("Adding multiple configurations for '$type'");
             push @config, @{ $this_config->{$outer_tag} };
         } else {
-            $log->is_debug
-                && $log->debug("Adding single configuration for '$type'");
+            $log->debug("Adding single configuration for '$type'");
             push @config, $this_config;
         }
     }

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -120,8 +120,7 @@ sub add_config_from_file {
             join ', ', _flatten( $params{$type} ) );
     }
 
-    $self->log->is_debug
-        && $self->log->debug("Adding condition configurations...");
+    $self->log->debug("Adding condition configurations...");
 
     if ( ref $params{condition} eq 'ARRAY' ) {
         foreach my $condition ( @{ $params{condition} } ) {
@@ -137,8 +136,7 @@ sub add_config_from_file {
         );
     }
 
-    $self->log->is_debug
-        && $self->log->debug("Adding validator configurations...");
+    $self->log->debug("Adding validator configurations...");
 
     if ( ref $params{validator} eq 'ARRAY' ) {
         foreach my $validator ( @{ $params{validator} } ) {
@@ -154,8 +152,7 @@ sub add_config_from_file {
         );
     }
 
-    $self->log->is_debug
-        && $self->log->debug("Adding persister configurations...");
+    $self->log->debug("Adding persister configurations...");
 
     if ( ref $params{persister} eq 'ARRAY' ) {
         foreach my $persister ( @{ $params{persister} } ) {
@@ -171,8 +168,7 @@ sub add_config_from_file {
         );
     }
 
-    $self->log->is_debug
-        && $self->log->debug("Adding action configurations...");
+    $self->log->debug("Adding action configurations...");
 
     if ( ref $params{action} eq 'ARRAY' ) {
         foreach my $action ( @{ $params{action} } ) {
@@ -184,8 +180,7 @@ sub add_config_from_file {
             Workflow::Config->parse_all_files( 'action', $params{action} ) );
     }
 
-    $self->log->is_debug
-        && $self->log->debug("Adding workflow configurations...");
+    $self->log->debug("Adding workflow configurations...");
 
     if ( ref $params{workflow} eq 'ARRAY' ) {
         foreach my $workflow ( @{ $params{workflow} } ) {
@@ -259,8 +254,7 @@ sub _add_workflow_config {
 
         $self->_load_observers($workflow_config);
 
-        $self->log->is_info
-            && $self->log->info("Added all workflow states...");
+        $self->log->info("Added all workflow states...");
     }
 
     return;
@@ -348,8 +342,7 @@ sub create_workflow {
         $wf_config, $self->{_workflow_state}{$wf_type}, $self );
     $wf->context( $context || Workflow::Context->new );
     $wf->last_update( DateTime->now( time_zone => $wf->time_zone() ) );
-    $self->log->is_info
-        && $self->log->info("Instantiated workflow object properly, persisting...");
+    $self->log->info("Instantiated workflow object properly, persisting...");
     my $persister = $self->get_persister( $wf_config->{persister} );
     my $id        = $persister->create_workflow($wf);
     $wf->id($id);
@@ -369,7 +362,7 @@ sub create_workflow {
             }
         )
     );
-    $self->log->is_info && $self->log->info("Created history object ok");
+    $self->log->info("Created history object ok");
 
     $self->_commit_transaction($wf);
 
@@ -463,15 +456,13 @@ sub save_workflow {
     my $persister = $self->get_persister( $wf_config->{persister} );
     eval {
         $persister->update_workflow($wf);
-        $self->log->is_info
-            && $self->log->info( "Workflow '", $wf->id, "' updated ok" );
+        $self->log->info( "Workflow '", $wf->id, "' updated ok" );
         my @unsaved = $wf->get_unsaved_history;
         foreach my $h (@unsaved) {
             $h->set_new_state( $wf->state );
         }
         $persister->create_history( $wf, @unsaved );
-        $self->log->is_info
-            && $self->log->info("Created necessary history objects ok");
+        $self->log->info("Created necessary history objects ok");
     };
     if ($EVAL_ERROR) {
         $wf->last_update($old_update);
@@ -508,8 +499,7 @@ sub _rollback_transaction {
 sub get_workflow_history {
     my ( $self, $wf ) = @_;
 
-    $self->log->is_debug
-        && $self->log->debug( "Trying to fetch history for workflow ", $wf->id );
+    $self->log->debug( "Trying to fetch history for workflow ", $wf->id );
     my $wf_config = $self->_get_workflow_config( $wf->type );
     my $persister = $self->get_persister( $wf_config->{persister} );
     return $persister->fetch_history($wf);

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -339,9 +339,7 @@ sub create_workflow {
     my $persister = $self->get_persister( $wf_config->{persister} );
     my $id        = $persister->create_workflow($wf);
     $wf->id($id);
-    $self->log->is_info
-        && $self->log->info(
-        "Persisted workflow with ID '$id'; creating history...");
+    $self->log->info("Persisted workflow with ID '$id'; creating history...");
     $persister->create_history(
         $wf,
         Workflow::History->new(
@@ -361,8 +359,8 @@ sub create_workflow {
 
     my $state = $wf->_get_workflow_state();
     if ( $state->autorun ) {
-        $self->log->is_info && $self->log->info( "State '$state' marked to be run ",
-            "automatically; executing that state/action..." );
+        $self->log->info( "State '$state' marked to be run ",
+                          "automatically; executing that state/action..." );
         $wf->_auto_execute_state($state);
     }
 
@@ -385,8 +383,7 @@ sub fetch_workflow {
     my $wf_info   = $persister->fetch_workflow($wf_id);
     return undef unless ($wf_info);
     $wf_info->{last_update} ||= '';
-    $self->log->is_debug
-        && $self->log->debug(
+    $self->log->debug(
         "Fetched data for workflow '$wf_id' ok: ",
         "[State: $wf_info->{state}] ",
         "[Last update: $wf_info->{last_update}]"

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -120,7 +120,7 @@ sub add_config_from_file {
             join ', ', _flatten( $params{$type} ) );
     }
 
-    $self->log->debug("Adding condition configurations...");
+    $self->log->debug( "Adding condition configurations..." );
 
     if ( ref $params{condition} eq 'ARRAY' ) {
         foreach my $condition ( @{ $params{condition} } ) {
@@ -136,7 +136,7 @@ sub add_config_from_file {
         );
     }
 
-    $self->log->debug("Adding validator configurations...");
+    $self->log->debug( "Adding validator configurations..." );
 
     if ( ref $params{validator} eq 'ARRAY' ) {
         foreach my $validator ( @{ $params{validator} } ) {
@@ -152,7 +152,7 @@ sub add_config_from_file {
         );
     }
 
-    $self->log->debug("Adding persister configurations...");
+    $self->log->debug( "Adding persister configurations..." );
 
     if ( ref $params{persister} eq 'ARRAY' ) {
         foreach my $persister ( @{ $params{persister} } ) {
@@ -168,7 +168,7 @@ sub add_config_from_file {
         );
     }
 
-    $self->log->debug("Adding action configurations...");
+    $self->log->debug( "Adding action configurations..." );
 
     if ( ref $params{action} eq 'ARRAY' ) {
         foreach my $action ( @{ $params{action} } ) {
@@ -180,7 +180,7 @@ sub add_config_from_file {
             Workflow::Config->parse_all_files( 'action', $params{action} ) );
     }
 
-    $self->log->debug("Adding workflow configurations...");
+    $self->log->debug( "Adding workflow configurations..." );
 
     if ( ref $params{workflow} eq 'ARRAY' ) {
         foreach my $workflow ( @{ $params{workflow} } ) {
@@ -254,7 +254,7 @@ sub _add_workflow_config {
 
         $self->_load_observers($workflow_config);
 
-        $self->log->info("Added all workflow states...");
+        $self->log->info( "Added all workflow states..." );
     }
 
     return;
@@ -342,7 +342,7 @@ sub create_workflow {
         $wf_config, $self->{_workflow_state}{$wf_type}, $self );
     $wf->context( $context || Workflow::Context->new );
     $wf->last_update( DateTime->now( time_zone => $wf->time_zone() ) );
-    $self->log->info("Instantiated workflow object properly, persisting...");
+    $self->log->info( "Instantiated workflow object properly, persisting..." );
     my $persister = $self->get_persister( $wf_config->{persister} );
     my $id        = $persister->create_workflow($wf);
     $wf->id($id);
@@ -362,7 +362,7 @@ sub create_workflow {
             }
         )
     );
-    $self->log->info("Created history object ok");
+    $self->log->info( "Created history object ok" );
 
     $self->_commit_transaction($wf);
 
@@ -462,7 +462,7 @@ sub save_workflow {
             $h->set_new_state( $wf->state );
         }
         $persister->create_history( $wf, @unsaved );
-        $self->log->info("Created necessary history objects ok");
+        $self->log->info( "Created necessary history objects ok" );
     };
     if ($EVAL_ERROR) {
         $wf->last_update($old_update);

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -22,18 +22,15 @@ sub import {
     my $package = caller;
     my $log = get_logger(__PACKAGE__);
     if ( defined $_[0] && $_[0] eq 'FACTORY' ) {
-        $log->is_debug
-            && $log->debug(
-            "Trying to import 'FACTORY' of type '$class' to '$package'");
+        $log->debug( "Trying to import 'FACTORY' of type '$class' to '$package'" );
         shift;
         my $instance = _initialize_instance($class);
 
         my $import_target = $package . '::FACTORY';
         no strict 'refs';
         unless ( defined &{$import_target} ) {
-            $log->is_debug
-                && $log->debug( "Target '$import_target' not yet defined, ",
-                "creating subroutine on the fly" );
+            $log->debug( "Target '$import_target' not yet defined, ",
+                         "creating subroutine on the fly" );
             *{$import_target} = sub { return $instance };
         }
         return $instance;
@@ -79,10 +76,8 @@ sub _initialize_instance {
 
     my $log = get_logger(__PACKAGE__);
     unless ( $INSTANCES{$class} ) {
-        $log->is_debug
-            && $log->debug(
-            "Creating empty instance of '$class' factory for ",
-            "singleton use" );
+        $log->debug( "Creating empty instance of '$class' factory for ",
+                     "singleton use" );
         my $instance = bless {} => $class;
         $instance->init();
         $INSTANCES{$class} = $instance;
@@ -95,12 +90,10 @@ sub _delete_instance {
 
     my $log = get_logger(__PACKAGE__);
     if ( $INSTANCES{$class} ) {
-        $log->is_debug
-            && $log->debug("Deleting instance of '$class' factory.");
+        $log->debug( "Deleting instance of '$class' factory." );
         delete $INSTANCES{$class};
     } else {
-        $log->is_debug
-            && $log->debug("No instance of '$class' factory found.");
+        $log->debug( "No instance of '$class' factory found." );
     }
 
     return;
@@ -115,9 +108,9 @@ sub add_config_from_file {
     _check_config_keys(%params);
 
     foreach my $type ( sort keys %params ) {
-        $self->log->is_debug
-            && $self->log->debug( "Using '$type' configuration file(s): ",
-            join ', ', _flatten( $params{$type} ) );
+        $self->log->debug(
+            sub { "Using '$type' configuration file(s): " .
+                      join( ', ', _flatten( $params{$type} ) ) } );
     }
 
     $self->log->debug( "Adding condition configurations..." );
@@ -287,7 +280,7 @@ sub _load_observers {
             } else {
                 my $error = 'subroutine not found';
                 $self->log->error( "Error loading subroutine '$observer_sub' in ",
-                    "class '$observer_class': $error" );
+                                   "class '$observer_class': $error" );
                 workflow_error $error;
             }
         } else {
@@ -302,14 +295,14 @@ sub _load_observers {
     if (@observers) {
         $self->{_workflow_observers}{$wf_type} = \@observers;
 
-        $self->log->is_info
-            && $self->log->info( "Added $observers_num to '$wf_type': ", join ', ', @observers );
+        $self->log->info(
+            sub { "Added $observers_num to '$wf_type': " .
+                      join( ', ', @observers ) } );
 
     } else {
         $self->{_workflow_observers}{$wf_type} = undef;
 
-        $self->log->is_info
-            && $self->log->info( "No observers added to '$wf_type'" );
+        $self->log->info( "No observers added to '$wf_type'" );
     }
 
     return $observers_num;
@@ -531,8 +524,7 @@ sub _add_action_config {
 
         foreach my $action_config ( @{$action} ) {
             my $name = $action_config->{name};
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Adding configuration for type '$type', action '$name'");
             $self->{_action_config}{$type}{$name} = $action_config;
             my $action_class = $action_config->{class};
@@ -541,8 +533,7 @@ sub _add_action_config {
                     "Action '$name' must be associated with a ",
                     "class using the 'class' attribute.";
             }
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Trying to include action class '$action_class'...");
             eval "require $action_class";
             if ($EVAL_ERROR) {
@@ -551,15 +542,13 @@ sub _add_action_config {
                 configuration_error
                     "Cannot include action class '$action_class': $msg";
             }
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Included action '$name' class '$action_class' ok");
             if ($self->_validate_action_config) {
                 my $validate_name = $action_class . '::validate_config';
                 if (exists &$validate_name) {
                     no strict 'refs';
-                    $self->log->is_debug
-                        && $self->log->debug(
+                    $self->log->debug(
                         "Validating configuration for action '$name'");
                     $validate_name->($action_config);
                 }
@@ -598,24 +587,21 @@ sub _add_persister_config {
     foreach my $persister_config (@all_persister_config) {
         next unless ( ref $persister_config eq 'HASH' );
         my $name = $persister_config->{name};
-        $self->log->is_debug
-            && $self->log->debug("Adding configuration for persister '$name'");
+        $self->log->debug( "Adding configuration for persister '$name'" );
         $self->{_persister_config}{$name} = $persister_config;
         my $persister_class = $persister_config->{class};
         unless ($persister_class) {
             configuration_error "You must specify a 'class' in persister ",
                 "'$name' configuration";
         }
-        $self->log->is_debug
-            && $self->log->debug(
+        $self->log->debug(
             "Trying to include persister class '$persister_class'...");
         eval "require $persister_class";
         if ($EVAL_ERROR) {
             configuration_error "Cannot include persister class ",
                 "'$persister_class': $EVAL_ERROR";
         }
-        $self->log->is_debug
-            && $self->log->debug(
+        $self->log->debug(
             "Included persister '$name' class '$persister_class' ",
             "ok; now try to instantiate persister..." );
         my $persister = eval { $persister_class->new($persister_config) };
@@ -624,8 +610,7 @@ sub _add_persister_config {
                 "'$name' of class '$persister_class': $EVAL_ERROR";
         }
         $self->{_persister}{$name} = $persister;
-        $self->log->is_debug
-            && $self->log->debug("Instantiated persister '$name' ok");
+        $self->log->debug( "Instantiated persister '$name' ok" );
     }
 }
 
@@ -681,24 +666,21 @@ sub _add_condition_config {
 
         foreach my $condition_config ( @{$c} ) {
             my $name = $condition_config->{name};
-            $self->log->is_debug
-                && $self->log->debug("Adding configuration for condition '$name'");
+            $self->log->debug( "Adding configuration for condition '$name'" );
             $self->{_condition_config}{$type}{$name} = $condition_config;
             my $condition_class = $condition_config->{class};
             unless ($condition_class) {
                 configuration_error "Condition '$name' must be associated ",
                     "with a class using the 'class' attribute";
             }
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Trying to include condition class '$condition_class'");
             eval "require $condition_class";
             if ($EVAL_ERROR) {
                 configuration_error "Cannot include condition class ",
                     "'$condition_class': $EVAL_ERROR";
             }
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Included condition '$name' class '$condition_class' ",
                 "ok; now try to instantiate condition..." );
             my $condition = eval { $condition_class->new($condition_config) };
@@ -707,8 +689,7 @@ sub _add_condition_config {
                     "Cannot create condition '$name': $EVAL_ERROR";
             }
             $self->{_conditions}{$type}{$name} = $condition;
-            $self->log->is_debug
-                && $self->log->debug("Instantiated condition '$name' ok");
+            $self->log->debug( "Instantiated condition '$name' ok" );
         }
     }
 }
@@ -770,8 +751,7 @@ sub _add_validator_config {
 
         for my $validator_config ( @{$v} ) {
             my $name = $validator_config->{name};
-            $self->log->is_debug
-                && $self->log->debug("Adding configuration for validator '$name'");
+            $self->log->debug( "Adding configuration for validator '$name'" );
             $self->{_validator_config}{$name} = $validator_config;
             my $validator_class = $validator_config->{class};
             unless ($validator_class) {
@@ -779,16 +759,14 @@ sub _add_validator_config {
                     "Validator '$name' must be associated with ",
                     "a class using the 'class' attribute.";
             }
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Trying to include validator class '$validator_class'");
             eval "require $validator_class";
             if ($EVAL_ERROR) {
                 workflow_error
                     "Cannot include validator class '$validator_class': $EVAL_ERROR";
             }
-            $self->log->is_debug
-                && $self->log->debug(
+            $self->log->debug(
                 "Included validator '$name' class '$validator_class' ",
                 " ok; now try to instantiate validator..."
                 );
@@ -797,8 +775,7 @@ sub _add_validator_config {
                 workflow_error "Cannot create validator '$name': $EVAL_ERROR";
             }
             $self->{_validators}{$name} = $validator;
-            $self->log->is_debug
-                && $self->log->debug("Instantiated validator '$name' ok");
+            $self->log->debug( "Instantiated validator '$name' ok" );
         }
     }
 }

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -198,8 +198,7 @@ sub create_workflow {
     if ($id) {
         push @fields, $wf_fields[0];
         push @values, $id;
-        $self->log->is_debug
-            && $self->log->debug("Got ID from pre_fetch_id: $id");
+        $self->log->debug("Got ID from pre_fetch_id: $id");
     }
     my $sql = 'INSERT INTO %s ( %s ) VALUES ( %s )';
 
@@ -383,8 +382,7 @@ sub fetch_history {
                 date        => $self->parser->parse_datetime( $row->[6] ),
             }
         );
-        $self->log->is_debug
-            && $self->log->debug("Fetched history object '$row->[0]'");
+        $self->log->debug("Fetched history object '$row->[0]'");
         $hist->set_saved();
         push @history, $hist;
     }

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -81,9 +81,8 @@ sub create_handle {
     $dbh->{PrintError} = 0;
     $dbh->{ChopBlanks} = 1;
     $dbh->{AutoCommit} = $self->autocommit();
-    $self->log->is_debug
-        && $self->log->debug( "Connected to database '",
-        $self->dsn, "' and ", "assigned to persister ok" );
+    $self->log->debug( "Connected to database '",
+                       $self->dsn, "' and ", "assigned to persister ok" );
 
     return $dbh;
 }
@@ -97,24 +96,19 @@ sub assign_generators {
 
     my ( $wf_gen, $history_gen );
     if ( $driver eq 'Pg' ) {
-        $self->log->is_debug
-            && $self->log->debug("Assigning ID generators for PostgreSQL");
+        $self->log->debug("Assigning ID generators for PostgreSQL");
         ( $wf_gen, $history_gen ) = $self->init_postgres_generators($params);
     } elsif ( $driver eq 'Oracle' ) {
-        $self->log->is_debug
-            && $self->log->debug("Assigning ID generators for Oracle");
+        $self->log->debug("Assigning ID generators for Oracle");
         ( $wf_gen, $history_gen ) = $self->init_oracle_generators($params);
     } elsif ( $driver eq 'mysql' ) {
-        $self->log->is_debug
-            && $self->log->debug("Assigning ID generators for MySQL");
+        $self->log->debug("Assigning ID generators for MySQL");
         ( $wf_gen, $history_gen ) = $self->init_mysql_generators($params);
     } elsif ( $driver eq 'SQLite' ) {
-        $self->log->is_debug
-            && $self->log->debug("Assigning ID generators for SQLite");
+        $self->log->debug("Assigning ID generators for SQLite");
         ( $wf_gen, $history_gen ) = $self->init_sqlite_generators($params);
     } else {
-        $self->log->is_debug
-            && $self->log->debug("Assigning random ID generators");
+        $self->log->debug("Assigning random ID generators");
         ( $wf_gen, $history_gen ) = $self->init_random_generators($params);
     }
     $self->workflow_id_generator($wf_gen);
@@ -376,8 +370,7 @@ sub fetch_history {
         $self->log->error("Caught error fetching workflow history: $EVAL_ERROR");
         persist_error $EVAL_ERROR;
     }
-    $self->log->is_debug
-        && $self->log->debug("Prepared and executed ok");
+    $self->log->debug("Prepared and executed ok");
 
     my @history = ();
     while ( my $row = $sth->fetchrow_arrayref ) {

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -39,8 +39,7 @@ sub init {
     $self->handle($self->create_handle);
     my $driver
         = $self->handle ? $self->handle->{Driver}->{Name} : ($params->{driver} || '');
-    $self->log->is_debug
-        && $self->log->debug("Pulled driver '$driver' from DBI DSN");
+    $self->log->debug( "Pulled driver '$driver' from DBI DSN" );
     $self->driver($driver);
     $self->assign_generators( $params, $driver );
     $self->log->info(

--- a/lib/Workflow/Persister/DBI/AutoGeneratedId.pm
+++ b/lib/Workflow/Persister/DBI/AutoGeneratedId.pm
@@ -27,16 +27,14 @@ sub new {
             configuration_error "If you specify 'from_handle' you must ",
                 "specify a value for 'handle_property'";
         }
-        $self->log->is_debug
-            && $self->log->debug( "Using '", $self->handle_property, "' from ", "'",
-            $self->from_handle, "' for ID generator" );
+        $self->log->debug( "Using '", $self->handle_property, "' from ", "'",
+                           $self->from_handle, "' for ID generator" );
     } elsif ( !$self->func_property ) {
         configuration_error "If you do not specify a value in 'from_handle' ",
             "you must specify a value for 'func_property'";
     } else {
-        $self->log->is_debug
-            && $self->log->debug( "Using database func() property '",
-            $self->func_property, "' for ID generator" );
+        $self->log->debug( "Using database func() property '",
+                           $self->func_property, "' for ID generator" );
     }
     return $self;
 }

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -41,9 +41,8 @@ sub init {
         my $context_key = $params->{extra_context_key} || $data_field;
         $self->context_key($context_key);
     }
-    $self->log->is_info
-        && $self->log->info( "Configured extra data fetch with: ",
-        join '; ', $self->table, $data_field, $self->context_key );
+    $self->log->info( "Configured extra data fetch with: ",
+                      join '; ', $self->table, $data_field, $self->context_key );
 }
 
 sub fetch_extra_workflow_data {

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -76,18 +76,18 @@ sub fetch_extra_workflow_data {
         if ( ref $data_field ) {
             foreach my $i ( 0 .. $#{$data_field} ) {
                 $wf->context->param( $data_field->[$i], $row->[$i] );
-                $self->log->is_info
-                    && $self->log->info(
-                    sprintf "Set data from %s.%s into context key %s ok",
-                    $self->table, $data_field->[$i], $data_field->[$i] );
+                $self->log->info(
+                    sub { sprintf "Set data from %s.%s into context key %s ok",
+                              $self->table, $data_field->[$i],
+                              $data_field->[$i] } );
             }
         } else {
             my $value = $row->[0];
             $wf->context->param( $self->context_key, $value );
-            $self->log->is_info
-                && $self->log->info(
-                sprintf "Set data from %s.%s into context key %s ok",
-                $self->table, $self->data_field, $self->context_key );
+            $self->log->info(
+                sub { sprintf "Set data from %s.%s into context key %s ok",
+                          $self->table, $self->data_field,
+                          $self->context_key } );
         }
     }
 }

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -49,8 +49,7 @@ sub init {
 sub fetch_extra_workflow_data {
     my ( $self, $wf ) = @_;
 
-    $self->log->is_debug
-        && $self->log->debug( "Fetching extra workflow data for '", $wf->id, "'" );
+    $self->log->debug( "Fetching extra workflow data for '", $wf->id, "'" );
 
     my $sql = q{SELECT %s FROM %s WHERE workflow_id = ?};
     my $data_field = $self->data_field;
@@ -61,10 +60,8 @@ sub fetch_extra_workflow_data {
         : $self->handle->quote_identifier($data_field);
     $sql = sprintf $sql, $select_data_fields,
         $self->handle->quote_identifier( $self->table );
-    $self->log->is_debug
-        && $self->log->debug("Using SQL: $sql");
-    $self->log->is_debug
-        && $self->log->debug( "Bind parameters: ", $wf->id );
+    $self->log->debug( "Using SQL: ", $sql);
+    $self->log->debug( "Bind parameters: ", $wf->id );
 
     my ($sth);
     eval {
@@ -75,8 +72,7 @@ sub fetch_extra_workflow_data {
         persist_error "Failed to retrieve extra data from table ",
             $self->table, ": $EVAL_ERROR";
     } else {
-        $self->log->is_debug
-            && $self->log->debug("Prepared/executed extra data fetch ok");
+        $self->log->debug("Prepared/executed extra data fetch ok");
         my $row = $sth->fetchrow_arrayref;
         if ( ref $data_field ) {
             foreach my $i ( 0 .. $#{$data_field} ) {

--- a/lib/Workflow/Persister/DBI/SequenceId.pm
+++ b/lib/Workflow/Persister/DBI/SequenceId.pm
@@ -25,8 +25,7 @@ sub new {
 sub pre_fetch_id {
     my ( $self, $dbh ) = @_;
     my $full_select = sprintf $self->sequence_select, $self->sequence_name;
-    $self->log->is_debug
-        && $self->log->debug("SQL to fetch sequence: $full_select");
+    $self->log->debug("SQL to fetch sequence: ", $full_select);
     my ($row);
     eval {
         my $sth = $dbh->prepare($full_select);

--- a/lib/Workflow/Persister/File.pm
+++ b/lib/Workflow/Persister/File.pm
@@ -42,8 +42,7 @@ sub create_workflow {
     my $generator = $self->workflow_id_generator;
     my $wf_id     = $generator->pre_fetch_id();
     $wf->id($wf_id);
-    $self->log->is_debug
-        && $self->log->debug("Generated workflow ID '$wf_id'");
+    $self->log->debug("Generated workflow ID '$wf_id'");
     $self->_serialize_workflow($wf);
     my $full_history_path = $self->_get_history_path($wf);
     mkdir( $full_history_path, 0777 )
@@ -55,8 +54,7 @@ sub create_workflow {
 sub fetch_workflow {
     my ( $self, $wf_id ) = @_;
     my $full_path = $self->_get_workflow_path($wf_id);
-    $self->log->is_debug
-        && $self->log->debug("Checking to see if workflow exists in '$full_path'");
+    $self->log->debug("Checking to see if workflow exists in '$full_path'");
     unless ( -f $full_path ) {
         $self->log->error("No file at path '$full_path'");
         persist_error "No workflow with ID '$wf_id' is available";
@@ -79,22 +77,18 @@ sub create_history {
     my ( $self, $wf, @history ) = @_;
     my $generator   = $self->history_id_generator;
     my $history_dir = $self->_get_history_path($wf);
-    $self->log->is_info
-        && $self->log->info("Will use directory '$history_dir' for history");
+    $self->log->info("Will use directory '$history_dir' for history");
     foreach my $history (@history) {
         if ( $history->is_saved ) {
-            $self->log->is_debug
-                && $self->log->debug("History object saved, skipping...");
+            $self->log->debug("History object saved, skipping...");
             next;
         }
-        $self->log->is_debug
-            && $self->log->debug("History object unsaved, continuing...");
+        $self->log->debug("History object unsaved, continuing...");
         my $history_id = $generator->pre_fetch_id();
         $history->id($history_id);
         my $history_file = catfile( $history_dir, $history_id );
         $self->serialize_object( $history_file, $history );
-        $self->log->is_info
-            && $self->log->info("Created history object '$history_id' ok");
+        $self->log->info("Created history object '$history_id' ok");
         $history->set_saved();
     }
 }
@@ -102,9 +96,7 @@ sub create_history {
 sub fetch_history {
     my ( $self, $wf ) = @_;
     my $history_dir = $self->_get_history_path($wf);
-    $self->log->is_debug
-        && $self->log->debug(
-        "Trying to read history files from dir '$history_dir'");
+    $self->log->debug("Trying to read history files from dir '$history_dir'");
     opendir( HISTORY, $history_dir )
         || persist_error "Cannot read history from '$history_dir': $!";
     my @history_files = grep { -f $_ }
@@ -113,8 +105,7 @@ sub fetch_history {
     my @histories = ();
 
     foreach my $history_file (@history_files) {
-        $self->log->is_debug
-            && $self->log->debug("Reading history from file '$history_file'");
+        $self->log->debug("Reading history from file '$history_file'");
         my $history = $self->constitute_object($history_file);
         $history->set_saved();
         push @histories, $history;
@@ -126,8 +117,7 @@ sub _serialize_workflow {
     my ( $self, $wf ) = @_;
     local $Data::Dumper::Indent = 1;
     my $full_path = $self->_get_workflow_path( $wf->id );
-    $self->log->is_debug
-        && $self->log->debug("Trying to write workflow to '$full_path'");
+    $self->log->debug("Trying to write workflow to '$full_path'");
     my %wf_info = (
         id          => $wf->id,
         state       => $wf->state,
@@ -142,9 +132,8 @@ sub _serialize_workflow {
 
 sub serialize_object {
     my ( $self, $path, $object ) = @_;
-    $self->log->is_info
-        && $self->log->info( "Trying to save object of type '",
-        ref($object), "' ", "to path '$path'" );
+    $self->log->info( "Trying to save object of type '",
+                      ref($object), "' ", "to path '$path'" );
     open( THINGY, '>', $path )
         || persist_error "Cannot write to '$path': $!";
     print THINGY Dumper($object)
@@ -167,9 +156,8 @@ sub constitute_object {
 
 sub _get_workflow_path {
     my ( $self, $wf_id ) = @_;
-    $self->log->is_info
-        && $self->log->info( "Creating workflow file from '",
-        $self->path, "' ", "and ID '$wf_id'" );
+    $self->log->info( "Creating workflow file from '",
+                      $self->path, "' ", "and ID '$wf_id'" );
     return catfile( $self->path, $wf_id . '_workflow' );
 }
 

--- a/lib/Workflow/Persister/File.pm
+++ b/lib/Workflow/Persister/File.pm
@@ -62,8 +62,7 @@ sub fetch_workflow {
         $self->log->error("No file at path '$full_path'");
         persist_error "No workflow with ID '$wf_id' is available";
     }
-    $self->log->is_debug
-        && $self->log->debug("File exists, reconstituting workflow");
+    $self->log->debug("File exists, reconstituting workflow");
     my $wf_info = eval { $self->constitute_object($full_path) };
     if ($EVAL_ERROR) {
         persist_error "Cannot reconstitute data from file for ",
@@ -139,8 +138,7 @@ sub _serialize_workflow {
 
     );
     $self->serialize_object( $full_path, \%wf_info );
-    $self->log->is_debug
-        && $self->log->debug("Wrote workflow ok");
+    $self->log->debug("Wrote workflow ok");
 }
 
 sub serialize_object {
@@ -153,8 +151,7 @@ sub serialize_object {
     print THINGY Dumper($object)
         || persist_error "Error writing to '$path': $!";
     close(THINGY) || persist_error "Cannot close '$path': $!";
-    $self->log->is_debug
-        && $self->log->debug("Wrote object to file ok");
+    $self->log->debug("Wrote object to file ok");
 }
 
 sub constitute_object {

--- a/lib/Workflow/Persister/File.pm
+++ b/lib/Workflow/Persister/File.pm
@@ -32,8 +32,7 @@ sub init {
             "specified in the 'path' key of the configuration ",
             "(given: '$params->{path}')";
     }
-    $self->log->is_info
-        && $self->log->info(
+    $self->log->info(
         "Using path for workflows and histories '$params->{path}'");
     $self->path( $params->{path} );
 }

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -167,9 +167,7 @@ sub get_autorun_action_name {
         workflow_error
             "$pre_error there are no actions available for execution.";
     }
-    $self->log->is_debug
-        && $self->log->debug(
-        "Auto-running state '$state' with action '$actions[0]'");
+    $self->log->debug("Auto-running state '$state' with action '$actions[0]'");
     return $actions[0];
 }
 
@@ -209,8 +207,7 @@ sub init {
 
     my $class = ref $self;
 
-    $self->log->is_debug
-        && $self->log->debug("Constructing '$class' object for state $name");
+    $self->log->debug("Constructing '$class' object for state $name");
 
     $self->state($name);
     $self->_factory($factory);
@@ -265,9 +262,8 @@ sub _assign_resulting_state_from_array {
         workflow_error "Errors found assigning 'resulting_state' to ",
             "action '$action_name' in state '$name': ", join '; ', @errors;
     }
-    $self->log->is_debug
-        && $self->log->debug( "Assigned multiple resulting states in '$name' and ",
-        "action '$action_name' from array ok" );
+    $self->log->debug( "Assigned multiple resulting states in '$name' and ",
+                       "action '$action_name' from array ok" );
     return \%new_resulting;
 }
 
@@ -281,8 +277,7 @@ sub _add_action_config {
             "is required -- if you do not want the state to ",
             "change, use the value '$no_change_value'.";
     }
-    $self->log->is_debug
-        && $self->log->debug("Adding '$state' '$action_name' config");
+    $self->log->debug("Adding '$state' '$action_name' config");
     $self->{_actions}{$action_name} = $action_config;
     my @action_conditions = $self->_create_condition_objects($action_config);
     $self->{_conditions}{$action_name} = \@action_conditions;

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -307,8 +307,7 @@ sub _create_condition_objects {
                 }
                 );
         } else {
-            $self->log->is_info
-                && $self->log->info(
+            $self->log->info(
                 "Fetching condition '$condition_info->{name}'");
             push @condition_objects,
                 $self->_factory()


### PR DESCRIPTION
# Description

The commits in this PR are of gradually increasing logging complexity, where more performance impact might be expected. The idea is to use these commits to benchmark performance of the change and use the outcomes to decide whether or not a specific commit crosses the acceptable threshold.

Fixes/addresses (If applicable) #89

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
This PR mostly simplifies code.

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
