### PR TITLE
Fix test failure such as TravisCI build 314 due to timing issues

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -90,6 +90,7 @@ SPOPS      = 0
 [Prereqs / TestRequires]
 DBD::Mock               = 0.10
 List::MoreUtils         = 0
+Mock::MonkeyPatch       = 0
 Test::Exception         = 0
 Test::More              = 0.88
 Test::Kwalitee          = 1.21 ; from Dist::Zilla


### PR DESCRIPTION

# Description

In TravisCI build 314, time wrapped to the next minute between writing
data to the various tables and the test verification (which generated
its own(!) time values).

This commit uses the same time value for both the output in the tables
as for test verification, preventing unnecessary failures.

## Type of change

- [x] Test improvement

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

I have tested effectiveness of this change by adding long `sleep` calls to the offending test (`sleep 66`).
