### PR TITLE
Close #107: allow configuration of the desired workflow class

### DIFF
--- a/lib/Workflow/Config.pm
+++ b/lib/Workflow/Config.pm
@@ -298,6 +298,7 @@ workflow pieces:
 =head2 workflow
 
    workflow
+      class         $
       type          $
       description   $
       persister     $
@@ -318,7 +319,7 @@ workflow pieces:
 
 =item *
 
-the 'type' and 'description' keys are at the top level
+the 'class', 'type' and 'description' keys are at the top level
 
 =item *
 

--- a/t/TestApp/CustomWorkflow.pm
+++ b/t/TestApp/CustomWorkflow.pm
@@ -1,0 +1,10 @@
+package TestApp::CustomWorkflow;
+
+use warnings;
+use strict;
+use 5.006;
+use base qw( Workflow );
+
+$TestApp::CustomWorkflow::VERSION = '0.01';
+
+1;

--- a/t/workflow.t
+++ b/t/workflow.t
@@ -10,7 +10,7 @@ eval "require DBI";
 if ( $@ ) {
     plan skip_all => 'DBI not installed';
 } else {
-    plan tests => 37;
+    plan tests => 38;
 }
 
 require_ok( 'Workflow' );
@@ -32,6 +32,8 @@ ok( ! $@, "Added configuration for workflow with observer" );
 {
     SomeObserver->clear_observations;
     my $wf = $factory->create_workflow( 'ObservedTicket' );
+    ok( $wf->isa( 'TestApp::CustomWorkflow' ),
+        'Instantiated workflow is of expected type TestApp::CustomWorkflow' );
     my @observations = SomeObserver->get_observations;
     is( scalar @observations, 2,
         'One observation sent on workflow create to two observers' );

--- a/t/workflow_observer.xml
+++ b/t/workflow_observer.xml
@@ -1,5 +1,5 @@
 <workflow>
-
+ <class>TestApp::CustomWorkflow</class>
  <type>ObservedTicket</type>
  <description>This is the workflow for sample application Ticket</description>
  <persister>TestPersister</persister>


### PR DESCRIPTION
# Description

Although the use of classes other than the Workflow class is supported
by the Factory, such custom classes need to be provided as arguments to
`create_workflow()` and `fetch_workflow()`.

This change adds configurability in line with the
general design and philosophy of the library.

Fixes/addresses (If applicable) #107 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

