### PR TITLE
Remove the concept of condition errors

### DIFF
--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -125,7 +125,7 @@ This documentation describes version 1.55 of this package
 
  use strict;
  use base qw( Workflow::Condition );
- use Workflow::Exception qw( condition_error configuration_error );
+ use Workflow::Exception qw( configuration_error );
 
  __PACKAGE__->mk_accessors( 'admin_group_id' );
 
@@ -145,12 +145,12 @@ This documentation describes version 1.55 of this package
      my $admin_ids = $self->admin_group_id;
      my $current_user = $wf->context->param( 'current_user' );
      unless ( $current_user ) {
-         condition_error "No user defined, cannot check groups";
+         return ''; # return false
      }
      foreach my $group ( @{ $current_user->get_groups } ) {
-         return if ( $admin_ids->{ $group->id } );
+         return 1 if ( $admin_ids->{ $group->id } ); # return true
      }
-     condition_error "Not member of any Admin groups";
+     return ''; # return false
  }
 
 =head1 DESCRIPTION
@@ -216,7 +216,7 @@ To create your own condition you should implement the following:
 This is optional, but called when the condition is first
 initialized. It may contain information you will want to initialize
 your condition with in C<\%params>, which are all the declared
-parameters in the condition declartion except for 'class' and 'name'.
+parameters in the condition declaration except for 'class' and 'name'.
 
 You may also do any initialization here -- you can fetch data from the
 database and store it in the class or object, whatever you need.
@@ -227,9 +227,13 @@ L<Workflow::Exception>).
 
 =head3 evaluate( $workflow )
 
-Determine whether your condition fails by throwing an exception. You
-can get the application context information necessary to process your
-condition from the C<$workflow> object.
+Determine whether your condition fails by returning a false value or
+a true value upon success. You can get the application context information
+necessary to process your condition from the C<$workflow> object.
+
+B<NOTE> Callers wanting to evaluate a condition, should not call
+this method directly, but rather use the C<< $class->evaluate_condition >>
+class method described below.
 
 =head3 _init
 

--- a/lib/Workflow/Condition/CheckReturn.pm
+++ b/lib/Workflow/Condition/CheckReturn.pm
@@ -6,7 +6,7 @@ use warnings;
 our $VERSION = '1.55';
 
 use base qw( Workflow::Condition::Nested );
-use Workflow::Exception qw( condition_error configuration_error );
+use Workflow::Exception qw( configuration_error );
 use English qw( -no_match_vars );
 
 __PACKAGE__->mk_accessors( 'condition', 'operator', 'argument' );
@@ -68,14 +68,7 @@ sub evaluate {
 
     my $condval = $self->evaluate_condition( $wf, $cond );
 
-    if ( eval "\$condval $op \$argval" ) {
-        return 1;
-    } else {
-        condition_error "Condition failed: '$condval' $op '$argval'";
-    }
-
-    configuration_error
-        "Unknown error in CheckReturn.pm: cond=$cond, op=$op, arg=$arg";
+    return eval "\$condval $op \$argval";
 }
 
 1;

--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -5,7 +5,7 @@ use strict;
 use base qw( Workflow::Condition );
 use Log::Log4perl qw( get_logger );
 use Safe;
-use Workflow::Exception qw( condition_error configuration_error );
+use Workflow::Exception qw( configuration_error );
 use English qw( -no_match_vars );
 
 $Workflow::Condition::Evaluate::VERSION = '1.55';
@@ -41,18 +41,11 @@ sub evaluate {
 
     $safe->share('$context');
     my $rv = $safe->reval($to_eval);
-    if ($EVAL_ERROR) {
-        condition_error
-            "Condition expressed in code threw exception: $EVAL_ERROR";
-    }
 
     $self->log->debug( "Safe eval ran ok, returned: '",
                        ( defined $rv ? $rv : '<undef>' ),
                        "'" );
-    unless ($rv) {
-        condition_error "Condition expressed by test '$to_eval' did not ",
-            "return a true value.";
-    }
+
     return $rv;
 }
 

--- a/lib/Workflow/Condition/GreedyOR.pm
+++ b/lib/Workflow/Condition/GreedyOR.pm
@@ -6,7 +6,7 @@ use warnings;
 our $VERSION = '1.55';
 
 use base qw( Workflow::Condition::Nested );
-use Workflow::Exception qw( condition_error configuration_error );
+use Workflow::Exception qw( configuration_error );
 use English qw( -no_match_vars );
 
 __PACKAGE__->mk_accessors('conditions');
@@ -37,12 +37,7 @@ sub evaluate {
         $result += $self->evaluate_condition( $wf, $cond ) ? 1 : 0;
     }
 
-    if ($result) {
-        return $result;
-    } else {
-        condition_error( "All of the conditions returned 'false': ",
-            join ', ', @{$conditions} );
-    }
+    return $result;
 }
 
 1;

--- a/lib/Workflow/Condition/HasUser.pm
+++ b/lib/Workflow/Condition/HasUser.pm
@@ -4,7 +4,6 @@ use warnings;
 use strict;
 use base qw( Workflow::Condition );
 use Log::Log4perl qw( get_logger );
-use Workflow::Exception qw( condition_error );
 
 $Workflow::Condition::HasUser::VERSION = '1.55';
 
@@ -23,10 +22,7 @@ sub evaluate {
     my $current_user = $wf->context->param($user_key);
     $self->log->debug( "Current user in the context is '$current_user' retrieved ",
         "using parameter key '$user_key'" );
-    unless ($current_user) {
-        condition_error
-            "No current user available in workflow context key '$user_key'";
-    }
+    return $current_user;
 }
 
 1;

--- a/lib/Workflow/Condition/LazyAND.pm
+++ b/lib/Workflow/Condition/LazyAND.pm
@@ -6,7 +6,7 @@ use warnings;
 our $VERSION = '1.55';
 
 use base qw( Workflow::Condition::Nested );
-use Workflow::Exception qw( condition_error configuration_error );
+use Workflow::Exception qw( configuration_error );
 use English qw( -no_match_vars );
 
 __PACKAGE__->mk_accessors('conditions');
@@ -36,13 +36,12 @@ sub evaluate {
     foreach my $cond ( @{$conditions} ) {
         my $result = $self->evaluate_condition( $wf, $cond );
         if ( not $result ) {
-            condition_error("Condition '$cond' returned 'false'");
+            return $result; # return false
         }
         $total++;
     }
 
-    return $total
-        || condition_error("No condition seems to have been run in LazyAND");
+    return $total; # returns false if no conditions ran: the contract
 }
 
 1;

--- a/lib/Workflow/Condition/LazyOR.pm
+++ b/lib/Workflow/Condition/LazyOR.pm
@@ -6,7 +6,7 @@ use warnings;
 our $VERSION = '1.55';
 
 use base qw( Workflow::Condition::Nested );
-use Workflow::Exception qw( condition_error configuration_error );
+use Workflow::Exception qw( configuration_error );
 use English qw( -no_match_vars );
 
 __PACKAGE__->mk_accessors('conditions');
@@ -40,7 +40,7 @@ sub evaluate {
             return $result;
         }
     }
-    condition_error("All nested conditions returned 'false'");
+    return ''; # false
 }
 
 1;

--- a/lib/Workflow/Exception.pm
+++ b/lib/Workflow/Exception.pm
@@ -6,10 +6,6 @@ use strict;
 # Declare some of our exceptions...
 
 use Exception::Class (
-    'Workflow::Exception::Condition' => {
-        isa         => 'Workflow::Exception',
-        description => 'Condition failed errors',
-    },
     'Workflow::Exception::Configuration' => {
         isa         => 'Workflow::Exception',
         description => 'Configuration errors',
@@ -29,14 +25,12 @@ use Log::Log4perl qw( get_logger );
 use Log::Log4perl::Level;
 
 my %TYPE_CLASSES = (
-    condition_error     => 'Workflow::Exception::Condition',
     configuration_error => 'Workflow::Exception::Configuration',
     persist_error       => 'Workflow::Exception::Persist',
     validation_error    => 'Workflow::Exception::Validation',
     workflow_error      => 'Workflow::Exception',
 );
 my %TYPE_LOGGING = (
-    condition_error     => $TRACE,
     configuration_error => $ERROR,
     persist_error       => $ERROR,
     validation_error    => $INFO,
@@ -72,11 +66,6 @@ sub _mythrow {
 }
 
 # Use 'goto' here to maintain the stack trace
-
-sub condition_error {
-    unshift @_, 'condition_error';
-    goto &_mythrow;
-}
 
 sub configuration_error {
     unshift @_, 'configuration_error';
@@ -225,8 +214,6 @@ This exception is thrown via </mythrow> when input data or similar of a workflow
 =over
 
 =item * B<Workflow::Exception> - import using C<workflow_error>
-
-=item * B<Workflow::Exception::Condition> - import using C<condition_error>
 
 =item * B<Workflow::Exception::Configuration> - import using C<configuration_error>
 

--- a/lib/Workflow/Exception.pm
+++ b/lib/Workflow/Exception.pm
@@ -179,12 +179,6 @@ makes for very readable code:
                 "frightfully wrong: $@",
                 { foo => 'bar' };
 
-=head3 condition_error
-
-This method transforms the error to a condition error.
-
-This exception is thrown via </mythrow> when a condition of a workflow is invalid.
-
 =head3 configuration_error
 
 This method transforms the error to a configuration error.

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -6,7 +6,6 @@ use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
 use Workflow::Condition;
 use Workflow::Condition::Evaluate;
-use Workflow::Condition::Negated;
 use Workflow::Exception qw( workflow_error condition_error );
 use Exception::Class;
 use Workflow::Factory qw( FACTORY );

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -6,6 +6,7 @@ use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
 use Workflow::Condition;
 use Workflow::Condition::Evaluate;
+use Workflow::Condition::Negated;
 use Workflow::Exception qw( workflow_error condition_error );
 use Exception::Class;
 use Workflow::Factory qw( FACTORY );

--- a/t/TestApp/Condition/AlwaysTrue.pm
+++ b/t/TestApp/Condition/AlwaysTrue.pm
@@ -3,7 +3,6 @@ package TestApp::Condition::AlwaysTrue;
 use strict;
 use base qw( Workflow::Condition );
 use Log::Log4perl       qw( get_logger );
-use Workflow::Exception qw( condition_error );
 
 $TestApp::Condition::AlwaysTrue::VERSION = '0.01';
 
@@ -12,6 +11,7 @@ sub evaluate {
     my $log = get_logger();
     $log->debug( "Trying to execute condition ", ref( $self ) );
     $log->debug( 'Condition met ok' );
+    return 1;
 }
 
 1;

--- a/t/TestApp/Condition/HasUserType.pm
+++ b/t/TestApp/Condition/HasUserType.pm
@@ -5,7 +5,6 @@ package TestApp::Condition::HasUserType;
 use strict;
 use base qw( Workflow::Condition );
 use Log::Log4perl       qw( get_logger );
-use Workflow::Exception qw( condition_error );
 
 $TestApp::Condition::HasUserType::VERSION = '0.01';
 
@@ -14,9 +13,10 @@ sub evaluate {
     my $log = get_logger();
     $log->debug( "Trying to execute condition ", ref( $self ) );
     unless ( $wf->context->param( 'current_user' ) ) {
-        condition_error "No value for 'current_user' set";
+        return 0;
     }
     $log->debug( 'Condition met ok' );
+    return 1;
 }
 
 1;

--- a/t/TestCachedApp/Condition/EvenCounts.pm
+++ b/t/TestCachedApp/Condition/EvenCounts.pm
@@ -5,7 +5,6 @@ use base qw( Workflow::Condition );
 
 use Log::Log4perl qw(get_logger);
 
-use Workflow::Exception qw( condition_error );
 
 my $log = get_logger();
 
@@ -20,9 +19,10 @@ sub evaluate {
         #  the same result twice: the first time on 'get_current_actions'
         #  and the second time on 'execute_action'
         $log->debug(__PACKAGE__, '::evaluate(', $count, '): fail');
-        condition_error "Current count is not divisible by 2";
+        return 0;
     }
     $log->debug(__PACKAGE__, '::evaluate(', $count, '): success');
+    return 1;
 }
 
 1;

--- a/t/exception.t
+++ b/t/exception.t
@@ -10,7 +10,7 @@ use English qw(-no_match_vars);
 use Log::Log4perl qw(:easy);
 Log::Log4perl->easy_init($OFF);
 
-use_ok( 'Workflow::Exception', qw(workflow_error validation_error condition_error configuration_error persist_error) );
+use_ok( 'Workflow::Exception', qw(workflow_error validation_error configuration_error persist_error) );
 
 {
     throws_ok {
@@ -33,13 +33,6 @@ use_ok( 'Workflow::Exception', qw(workflow_error validation_error condition_erro
         validation_error('test ', 'validation_error', { foo => 'bar' })
     } 'Exception::Class::Base', 'workflow validation_error exception';
     like($EVAL_ERROR, qr/unknown field foo passed to constructor for class Workflow::Exception::Validation/, 'asserting exception text');
-}
-
-{
-    throws_ok {
-        condition_error('test ', 'condition_error')
-    } 'Workflow::Exception', 'workflow condition_error exception';
-    like($EVAL_ERROR, qr/test condition_error/, 'asserting exception text');
 }
 
 {


### PR DESCRIPTION
# Description

The idea that a condition evaluating to 'false' is an error
is a design misfeature causing a lot more code to be in Workflow
than required.

This commit moves condition evalutation to a simple true/false
return value.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
