### PR TITLE
Fix #121: make Workflow::State->get_conditions() return all conditions

### DIFF
--- a/lib/Workflow/Condition/Negated.pm
+++ b/lib/Workflow/Condition/Negated.pm
@@ -1,0 +1,87 @@
+package Workflow::Condition::Negated;
+
+use strict;
+use warnings;
+
+our $VERSION = '1.54';
+
+use base qw( Workflow::Condition );
+
+my @FIELDS = qw( name class negated );
+__PACKAGE__->mk_accessors(@FIELDS);
+
+sub _init {
+    my ( $self, $params ) = @_;
+    my $negated = $params->{name};
+    $negated =~ s/ \A ! //gx;
+    $self->negated( $negated );
+    $self->SUPER::_init($params);
+}
+
+sub evaluate {
+    my ($self, $wf) = @_;
+    return not $self->evaluate_condition($wf, $self->negated);
+}
+
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Workflow::Condition::Negated - Negate workflow condition result
+
+=head1 VERSION
+
+This documentation describes version 1.54 of this package
+
+=head1 DESCRIPTION
+
+This class is used by C<Workflow::State> to handle I<negated conditions>:
+conditions of which the referring name starts with an exclamation mark (!).
+
+Such conditions refer to another condition (by the name after the '!') and
+return the negated result of the condition referred to (true becomes false
+while false becomes true).
+
+=head1 SYNOPSIS
+
+In condition.xml:
+
+    <condition name="check_approvals" class="...">
+    </condition>
+
+In workflow.xml:
+
+    <state name="CHECK_APPROVALS" autorun="yes">
+        <action name="null_1" resulting_state="APPROVED">
+            <condition name="check_approvals" />
+        </action>
+        <action name="null_2" resulting_state="REJECTED">
+            <condition name="!check_approvals" />
+        </action>
+    </state>
+
+=cut
+
+=head1 AUTHORS
+
+See L<Workflow>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2004-2021 Chris Winters. All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+Please see the F<LICENSE>
+
+=head1 AUTHORS
+
+Please see L<Workflow>
+
+=cut

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -44,6 +44,7 @@ sub import {
 require Workflow;
 require Workflow::Action;
 require Workflow::Condition;
+require Workflow::Condition::Negated;
 require Workflow::Config;
 require Workflow::Context;
 require Workflow::History;
@@ -736,6 +737,21 @@ sub get_condition {
     # the current Workflow type.
     if ( not defined $condition ) {
         $condition = $self->{_conditions}{'default'}{$name};
+    }
+
+    if ( not defined $condition
+         and $name =~ m/ \A ! /msx ) {
+        my $negated = $name;
+        $negated =~ s/ \A ! //gx;
+
+        if ( $self->get_condition( $negated, $type ) ) {
+            $condition = Workflow::Condition::Negated->new(
+                { name => $name }
+                );
+
+            $type = 'default' unless defined $type;
+            $self->{_conditions}{$type}{$name} = $condition;
+        }
     }
 
     unless ($condition) {

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -6,6 +6,7 @@ use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
 use Workflow::Condition;
 use Workflow::Condition::Evaluate;
+use Workflow::Condition::Negated;
 use Workflow::Exception qw( workflow_error condition_error );
 use Exception::Class;
 use Workflow::Factory qw( FACTORY );
@@ -94,12 +95,7 @@ sub evaluate_action {
 
     my @conditions = $self->get_conditions($action_name);
     foreach my $condition (@conditions) {
-        my $condition_name;
-        if ( exists $condition->{name} ) {    # hash only, no object
-            $condition_name = $condition->{name};
-        } else {
-            $condition_name = $condition->name;
-        }
+        my $condition_name = $condition->name;
 
         my $rv;
         eval {
@@ -310,7 +306,9 @@ sub _create_condition_objects {
                 # the real object will be gotten from the factory
                 # if needed in evaluate_action
                 push @condition_objects,
-                    { 'name' => $condition_info->{name} };
+                    Workflow::Condition::Negated->new(
+                        { 'name' => $condition_info->{name} }
+                    );
             } else {
                 $self->log->is_info
                     && $self->log->info(

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -6,7 +6,6 @@ use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
 use Workflow::Condition;
 use Workflow::Condition::Evaluate;
-use Workflow::Condition::Negated;
 use Workflow::Exception qw( workflow_error condition_error );
 use Exception::Class;
 use Workflow::Factory qw( FACTORY );
@@ -297,26 +296,12 @@ sub _create_condition_objects {
                 }
                 );
         } else {
-            if ( $condition_info->{name} =~ m{ \A ! }xms ) {
-                $self->log->is_debug
-                    && $self->log->debug(
-                    "Condition starts with !, pushing hash with name only");
-
-                # push a hashref only, not a real object
-                # the real object will be gotten from the factory
-                # if needed in evaluate_action
-                push @condition_objects,
-                    Workflow::Condition::Negated->new(
-                        { 'name' => $condition_info->{name} }
-                    );
-            } else {
-                $self->log->is_info
-                    && $self->log->info(
-                    "Fetching condition '$condition_info->{name}'");
-                push @condition_objects,
-                    $self->_factory()
-                    ->get_condition( $condition_info->{name}, $self->type() );
-            }
+            $self->log->is_info
+                && $self->log->info(
+                "Fetching condition '$condition_info->{name}'");
+            push @condition_objects,
+                $self->_factory()
+                ->get_condition( $condition_info->{name}, $self->type() );
         }
     }
     return @condition_objects;


### PR DESCRIPTION
# Description

Instead of returning a list of hashes and objects (which is undocumented
behaviour on a public function...), return a list of condition objects
as per the documentation.

While at it, clean up code that works around the undocumented behaviour.

Fixes/addresses (If applicable) #121

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

