### PR TITLE
Fix #113: Support action attribute to be defined as part of State config

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -92,7 +92,7 @@ sub get_action {
     $self->log->is_debug
         && $self->log->debug("Action '$action_name' exists in state '$state'");
 
-    my $action = $self->_factory()->get_action( $self, $action_name );
+    my $action = $self->_get_workflow_state()->get_action( $self, $action_name );
 
     # This will throw an exception which we want to bubble up
     $wf_state->evaluate_action( $self, $action_name );

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -577,21 +577,21 @@ sub _add_action_config {
     }
 }
 
-sub get_action {
+sub get_action_config {
     my ( $self, $wf, $action_name ) = @_;
-    my $config;
-
-    # Check for a specific action type.
-    $config = $self->{_action_config}{ $wf->type }{$action_name};
-
-    # Check for a default if no type is available.
+    my $config = $self->{_action_config}{ $wf->type }{$action_name};
     $config = $self->{_action_config}{default}{$action_name}
-        if not keys %{$config};
+        unless ($config and %{$config});
 
     unless ($config) {
         workflow_error "No action with name '$action_name' available";
     }
+    return $config;
+}
 
+sub get_action {
+    my ( $self, $wf, $action_name ) = @_;
+    my $config       = $self->get_action_config( $wf, $action_name );;
     my $action_class = $config->{class};
     return $action_class->new( $wf, $config );
 }
@@ -1000,7 +1000,7 @@ object itself. Under the covers it calls this.
 
 Returns: list of L<Workflow::History> objects
 
-=head3 get_action( $workflow, $action_name )
+=head3 get_action( $workflow, $action_name ) [ deprecated ]
 
 Retrieves the action C<$action_name> from workflow C<$workflow>. Note
 that this does not do any checking as to whether the action is proper
@@ -1010,7 +1010,15 @@ propriety of the action) to instantiate new actions.
 
 Throws exception if no action with name C<$action_name> available.
 
-Returns: L<Workflow::Action> object
+=head3 get_action_config( $workflow, $action_name )
+
+Retrieves the configuration for action C<$action_name> as specified in
+the actions configuration file, with the keys listed in
+L<the 'action' section of Workflow::Config|Workflow::Config/"action">
+
+Throws exception if no action with name C<$action_name> available.
+
+Returns: A hash with the configuration as its keys.
 
 =head3 get_persister( $persister_name )
 

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -27,6 +27,17 @@ sub get_conditions {
     return @{ $self->{_conditions}{$action_name} };
 }
 
+sub get_action {
+    my ( $self, $wf, $action_name ) = @_;
+    my $common_config =
+        $self->_factory->get_action_config($wf, $action_name);
+    my $state_config  = $self->{_actions}{$action_name};
+    my $config        = { %{$common_config}, %{$state_config} };
+    my $action_class  = $common_config->{class};
+
+    return $action_class->new( $wf, $config );
+}
+
 sub contains_action {
     my ( $self, $action_name ) = @_;
     return $self->{_actions}{$action_name};
@@ -449,6 +460,14 @@ stop automatic execution if it does not have a single action to execute.
 Returns a list of L<Workflow::Condition> objects for action
 C<$action_name>. Throws exception if object does not contain
 C<$action_name> at all.
+
+=head3 get_action( $workflow, $action_name )
+
+Returns an L<Workflow::Action> instance initialized using both the
+global configuration provided to the named action in the "action
+configuration" provided to the factory as well as any configuration
+specified as part of the listing of actions in the state of the
+workflow declaration.
 
 =head3 contains_action( $action_name )
 

--- a/t/TestApp/Action/TicketComment.pm
+++ b/t/TestApp/Action/TicketComment.pm
@@ -6,6 +6,17 @@ use Log::Log4perl qw( get_logger );
 
 $TestApp::Action::TicketComment::VERSION  = '1.02';
 
+__PACKAGE__->mk_accessors(qw(index));
+
+### Straight out of the Workflow::Action->new() documentation
+sub new {
+    my ($class, $wf, $params) = @_;
+    my $self = $class->SUPER::new($wf, $params);
+    $self->index($params->{index}) if defined $params->{index};
+
+    return $self;
+}
+
 sub execute {
     my ( $self, $wf ) = @_;
     my $log = get_logger();

--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -195,6 +195,9 @@ sub run_state_tests{
   @actions = $wf_state->get_available_action_names( $wf2 );
   is( (scalar @actions), 2, 'Got back two available actions.');
   ok(all { defined $_ } qw(TIX_EDIT TIX_COMMENT), 'Got TIX_EDIT and TIX_COMMENT as available actions.');
+
+  $wf_action = $wf->get_action( 'TIX_COMMENT' );
+  is( $wf_action->index, 42, 'Got config specified in State' );
 }
 
 'I am true!';

--- a/t/state.t
+++ b/t/state.t
@@ -3,7 +3,7 @@
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;
-use Test::More  tests => 21;
+use Test::More  tests => 22;
 
 require_ok( 'Workflow::State' );
 

--- a/t/state_perl.t
+++ b/t/state_perl.t
@@ -3,7 +3,7 @@
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;
-use Test::More  tests => 19;
+use Test::More  tests => 20;
 
 require_ok( 'Workflow::State' );
 

--- a/t/workflow.perl
+++ b/t/workflow.perl
@@ -19,7 +19,8 @@ $VAR1 = {
                        'action' => [
                                    {
                                      'name' => 'TIX_COMMENT',
-                                     'resulting_state' => 'NOCHANGE'
+                                     'resulting_state' => 'NOCHANGE',
+                                     'index' => '42'
                                    },
                                    {
                                      'name' => 'TIX_EDIT',

--- a/t/workflow.xml
+++ b/t/workflow.xml
@@ -12,7 +12,7 @@
 
  <state name="TIX_CREATED">
      <description>State of ticket after it has been created</description>
-     <action name="TIX_COMMENT">
+     <action name="TIX_COMMENT" index="42">
        <resulting_state return="never" state="TIX_COMMENT" />
        <resulting_state return="*" state="NOCHANGE" />
      </action>


### PR DESCRIPTION
# Description

In the documentation for Workflow::Action, there's an explicit example
under the documentation of the C<new()> method which shows how to add
configuration (and index number) to an action class and copy that
configuration into an attribute of the Action's instance.

With this fix, that scenario is tested and has been fixed to work.

Fixes/addresses (If applicable) #113 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x ] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
