### PR TITLE
When using action groups, include 'default'-type actions

### DIFF
--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -59,12 +59,11 @@ sub get_available_action_names {
 
     foreach my $action_name (@all_actions) {
 
-        #From Ivan Paponov
-        my $action_group = $self->_factory()
-            ->{_action_config}{ $self->type() }{$action_name}{'group'};
-
-        if ( defined $group && length $group ) {
-            if ( $action_group ne $group ) {
+        if ( $group ) {
+            my $action_config =
+                $self->_factory()->get_action_config( $wf, $action_name );
+            if ( defined $action_config->{group}
+                 and $action_config->{group} ne $group ) {
                 next;
             }
         }


### PR DESCRIPTION
# Description

Resolve the issue by accessing the factory through its API.

Going directly through the factory's internals breaks abstractions
and causes bugs, like forgetting to check for actions in the
default workflow (named 'default') type.

Fixes #129.

__NOTE__ Please note that this makes groups apply across all actions. While I'd expect it to be uncommon that a typed workflow expects generally available actions (those in the 'default' type) to have been assigned to its groups, it's not entirely inconceivable that users expect groups to apply to all actions (typed and default alike). The `get_available_action_names()` method also does not document group membership checks being limited to typed actions. (Also note that `Workflow::Action` does not document group membership at all.)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
