### PR TITLE
Action group doc

### DIFF
--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -14,7 +14,7 @@ use Carp qw(croak);
 
 $Workflow::Action::VERSION = '1.55';
 
-my @PROPS    = qw( name class description );
+my @PROPS    = qw( name class description group );
 my @INTERNAL = qw( _factory );
 __PACKAGE__->mk_accessors( @PROPS, @INTERNAL );
 
@@ -109,6 +109,7 @@ sub init {
     $self->class( $copy_params{class} );
     $self->name( $copy_params{name} );
     $self->description( $copy_params{description} );
+    $self->group( $copy_params{group} );
 
     ## init normal fields
     my @fields = $self->normalize_array( $copy_params{field} );
@@ -145,7 +146,7 @@ sub init {
     my @validator_info = $self->normalize_array( $copy_params{validator} );
     $self->add_validators(@validator_info);
 
-    delete @copy_params{qw( class name description field validator )};
+    delete @copy_params{(@PROPS, qw( field validator ))};
 
     # everything else is just a passthru param
 
@@ -265,6 +266,11 @@ The Perl class which provides the behaviour of the action.
 =item * C<description>
 
 A free text field describing the action.
+
+=item * C<group>
+
+The group for use with the L<Workflow::State/get_available_action_names>
+C<$group> filter.
 
 =item * C<name>
 

--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -252,6 +252,36 @@ to all types. For example:
 The type must match an existing workflow type or the action will never
 be called.
 
+=head1 STANDARD ATTRIBUTES
+
+Each action supports the following attributes:
+
+=over
+
+=item * C<class>
+
+The Perl class which provides the behaviour of the action.
+
+=item * C<description>
+
+A free text field describing the action.
+
+=item * C<name>
+
+The name by which workflows can reference the action.
+
+=item * C<type>
+
+Associates the action with workflows of the same type, when set. When
+not set, the action is available to all workflows.
+
+=back
+
+
+These attributes (except for the C<class> attribute) all map to instance
+properties by the same name.
+
+
 =head1 ADDITIONAL ATTRIBUTES
 
 You can validate additional attributes in of your action by doing two things:


### PR DESCRIPTION
# Description

Follow-up to #129. Documents the ability to declare groups (and adds a group property to the Workflow::Action class) for use with Workflow::State->get_available_action_names().


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
