### PR TITLE
Eliminate undefined value warning

### DIFF
--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -42,7 +42,9 @@ sub init {
         $self->context_key($context_key);
     }
     $self->log->info( "Configured extra data fetch with: ",
-                      join '; ', $self->table, $data_field, $self->context_key );
+                      join( '; ', $self->table, $data_field,
+                            ( defined $self->context_key
+                              ? $self->context_key : '' ) ) );
 }
 
 sub fetch_extra_workflow_data {


### PR DESCRIPTION
# Description

Before 1.55, this warning was hidden behind a `$log->is_info` check;
with that check removed, 1.55 now warns when no explicit `context_key`
is specified in the XML config.

Note that no context_key being specified, is the regular case when
the data field is a list of comma separated column names.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

