### PR TITLE
Rename Workflow::Action::InputField to Workflow::InputField

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -985,11 +985,11 @@ One of the conditions for the action in this state is not met.
 
 =head3 get_action_fields( $action_name )
 
-Return a list of L<Workflow::Action::InputField> objects for the given
+Return a list of L<Workflow::InputField> objects for the given
 C<$action_name>. If C<$action_name> not in the current state or not
 accessible by the environment an exception is thrown.
 
-Returns: list of L<Workflow::Action::InputField> objects
+Returns: list of L<Workflow::InputField> objects
 
 =head3 add_history( @( \%params | $wf_history_object ) )
 

--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -7,7 +7,7 @@ use warnings;
 use strict;
 use base qw( Workflow::Base );
 use Log::Log4perl qw( get_logger );
-use Workflow::Action::InputField;
+use Workflow::InputField;
 use Workflow::Validator::HasRequiredField;
 use Workflow::Factory qw( FACTORY );
 use Carp qw(croak);
@@ -119,7 +119,7 @@ sub init {
         } else {
             $self->log->debug("Using standard field class");
             $self->add_fields(
-                Workflow::Action::InputField->new($field_info) );
+                Workflow::InputField->new($field_info) );
         }
     }
 
@@ -382,15 +382,15 @@ an example on how you easily do this by overriding new():
 
 =head3 required_fields()
 
-Return a list of L<Workflow::Action::InputField> objects that are required.
+Return a list of L<Workflow::InputField> objects that are required.
 
 =head3 optional_fields()
 
-Return a list of L<Workflow::Action::InputField> objects that are optional.
+Return a list of L<Workflow::InputField> objects that are optional.
 
 =head3 fields()
 
-Return a list of all L<Workflow::Action::InputField> objects
+Return a list of all L<Workflow::InputField> objects
 associated with this action.
 
 
@@ -404,7 +404,7 @@ It sets up the necessary validators based on the on configured actions, input fi
 
 =head3 add_field( @fields )
 
-Add one or more L<Workflow::Action::InputField>s to the action.
+Add one or more L<Workflow::InputField>s to the action.
 
 =head3 add_validators( @validator_config )
 

--- a/lib/Workflow/InputField.pm
+++ b/lib/Workflow/InputField.pm
@@ -1,4 +1,4 @@
-package Workflow::Action::InputField;
+package Workflow::InputField;
 
 use warnings;
 use strict;
@@ -7,7 +7,7 @@ use Log::Log4perl qw( get_logger );
 use Workflow::Exception qw( configuration_error );
 use English qw( -no_match_vars );
 
-$Workflow::Action::InputField::VERSION = '1.55';
+$Workflow::InputField::VERSION = '1.55';
 
 my @PROPS = qw( name label description type requirement
     source_class source_list class );
@@ -117,7 +117,7 @@ __END__
 
 =head1 NAME
 
-Workflow::Action::InputField - Metadata about information required by an Action
+Workflow::InputField - Metadata about information required by an Action
 
 =head1 VERSION
 
@@ -205,7 +205,7 @@ extra properties. Just derive your custom fields class like so:
   use warnings;
   use strict;
 
-  use base qw( Workflow::Action::InputField );
+  use base qw( Workflow::InputField );
   use Workflow::Exception qw( workflow_error );
 
   # extra action class properties

--- a/t/action_field.t
+++ b/t/action_field.t
@@ -6,18 +6,18 @@ use TestUtil;
 use Test::Exception;
 use Test::More  tests => 16;
 
-require_ok( 'Workflow::Action::InputField' );
+require_ok( 'Workflow::InputField' );
 
 my $action;
 
-dies_ok { $action = Workflow::Action::InputField->new({}) };
+dies_ok { $action = Workflow::InputField->new({}) };
 
-ok($action = Workflow::Action::InputField->new({
+ok($action = Workflow::InputField->new({
     name        => 'test',
     is_required => 'yes',
 }));
 
-isa_ok($action, 'Workflow::Action::InputField');
+isa_ok($action, 'Workflow::InputField');
 
 my @values;
 
@@ -38,7 +38,7 @@ is($action->is_required, 'yes');
 
 is($action->is_optional, 'no');
 
-ok($action = Workflow::Action::InputField->new({
+ok($action = Workflow::InputField->new({
     name        => 'test',
     is_required => 'no',
 }));
@@ -47,7 +47,7 @@ is($action->is_required, 'no');
 
 is($action->is_optional, 'yes');
 
-ok($action = Workflow::Action::InputField->new({
+ok($action = Workflow::InputField->new({
     name        => 'test',
 }));
 


### PR DESCRIPTION
# Description

As per the note in the "2.0" project, rename Workflow::InputField
to be a toplevel class+module similar to the other core concepts
in the Workflow library.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

Not applicable:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
