### PR TITLE
State internal accessors

### DIFF
--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -236,7 +236,7 @@ sub init {
     }
 }
 
-sub _assign_resulting_state_from_array {
+sub _assign_next_state_from_array {
     my ( $self, $action_name, $resulting ) = @_;
     my $name          = $self->state;
     my @errors        = ();
@@ -262,14 +262,14 @@ sub _assign_resulting_state_from_array {
     return \%new_resulting;
 }
 
-sub _create_resulting_state {
+sub _create_next_state {
     my ( $self, $action_name, $resulting ) = @_;
 
     if ( my $resulting_type = ref $resulting ) {
         if ( $resulting_type eq 'ARRAY' ) {
             $resulting
-                = $self->_assign_resulting_state_from_array( $action_name,
-                                                             $resulting );
+                = $self->_assign_next_state_from_array( $action_name,
+                                                        $resulting );
         }
     }
 
@@ -294,7 +294,7 @@ sub _add_action_config {
 
     # Removes 'resulting_state' key from action_config
     $self->_next_state->{$action_name} =
-        $self->_create_resulting_state( $action_name, $resulting_state );
+        $self->_create_next_state( $action_name, $resulting_state );
 
     # Removes 'condition' key from action_config
     $self->_conditions->{$action_name} = [

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -14,7 +14,7 @@ use English qw( -no_match_vars );
 $Workflow::State::VERSION = '1.55';
 
 my @FIELDS   = qw( state description type );
-my @INTERNAL = qw( _test_condition_count _factory _actions );
+my @INTERNAL = qw( _test_condition_count _factory _actions _conditions );
 __PACKAGE__->mk_accessors( @FIELDS, @INTERNAL );
 
 
@@ -24,7 +24,7 @@ __PACKAGE__->mk_accessors( @FIELDS, @INTERNAL );
 sub get_conditions {
     my ( $self, $action_name ) = @_;
     $self->_contains_action_check($action_name);
-    return @{ $self->{_conditions}{$action_name} };
+    return @{ $self->_conditions->{$action_name} };
 }
 
 sub get_action {
@@ -211,6 +211,7 @@ sub init {
     $self->state($name);
     $self->_factory($factory);
     $self->_actions( {} );
+    $self->_conditions( {} );
 
     # Note this is the workflow type.
     $self->type( $config->{type} );
@@ -280,7 +281,7 @@ sub _add_action_config {
     $self->log->debug("Adding '$state' '$action_name' config");
     $self->_actions->{$action_name} = $action_config;
     my @action_conditions = $self->_create_condition_objects($action_config);
-    $self->{_conditions}{$action_name} = \@action_conditions;
+    $self->_conditions->{$action_name} = \@action_conditions;
 }
 
 sub _create_condition_objects {

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -14,7 +14,7 @@ use English qw( -no_match_vars );
 $Workflow::State::VERSION = '1.55';
 
 my @FIELDS   = qw( state description type );
-my @INTERNAL = qw( _test_condition_count _factory );
+my @INTERNAL = qw( _test_condition_count _factory _actions );
 __PACKAGE__->mk_accessors( @FIELDS, @INTERNAL );
 
 
@@ -31,7 +31,7 @@ sub get_action {
     my ( $self, $wf, $action_name ) = @_;
     my $common_config =
         $self->_factory->get_action_config($wf, $action_name);
-    my $state_config  = $self->{_actions}{$action_name};
+    my $state_config  = $self->_actions->{$action_name};
     my $config        = { %{$common_config}, %{$state_config} };
     my $action_class  = $common_config->{class};
 
@@ -40,12 +40,12 @@ sub get_action {
 
 sub contains_action {
     my ( $self, $action_name ) = @_;
-    return $self->{_actions}{$action_name};
+    return $self->_actions->{$action_name};
 }
 
 sub get_all_action_names {
     my ($self) = @_;
-    return keys %{ $self->{_actions} };
+    return keys %{ $self->_actions };
 }
 
 sub get_available_action_names {
@@ -135,7 +135,7 @@ sub evaluate_action {
 sub get_next_state {
     my ( $self, $action_name, $action_return ) = @_;
     $self->_contains_action_check($action_name);
-    my $resulting_state = $self->{_actions}{$action_name}{resulting_state};
+    my $resulting_state = $self->_actions->{$action_name}{resulting_state};
     return $resulting_state unless ( ref($resulting_state) eq 'HASH' );
 
     if ( defined $action_return ) {
@@ -210,6 +210,7 @@ sub init {
 
     $self->state($name);
     $self->_factory($factory);
+    $self->_actions( {} );
 
     # Note this is the workflow type.
     $self->type( $config->{type} );
@@ -277,7 +278,7 @@ sub _add_action_config {
             "change, use the value '$no_change_value'.";
     }
     $self->log->debug("Adding '$state' '$action_name' config");
-    $self->{_actions}{$action_name} = $action_config;
+    $self->_actions->{$action_name} = $action_config;
     my @action_conditions = $self->_create_condition_objects($action_config);
     $self->{_conditions}{$action_name} = \@action_conditions;
 }

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -14,7 +14,8 @@ use English qw( -no_match_vars );
 $Workflow::State::VERSION = '1.55';
 
 my @FIELDS   = qw( state description type );
-my @INTERNAL = qw( _test_condition_count _factory _actions _conditions );
+my @INTERNAL = qw( _test_condition_count _factory _actions _conditions
+    _next_state );
 __PACKAGE__->mk_accessors( @FIELDS, @INTERNAL );
 
 
@@ -135,7 +136,7 @@ sub evaluate_action {
 sub get_next_state {
     my ( $self, $action_name, $action_return ) = @_;
     $self->_contains_action_check($action_name);
-    my $resulting_state = $self->_actions->{$action_name}{resulting_state};
+    my $resulting_state = $self->_resulting_state->{$action_name};
     return $resulting_state unless ( ref($resulting_state) eq 'HASH' );
 
     if ( defined $action_return ) {
@@ -212,6 +213,7 @@ sub init {
     $self->_factory($factory);
     $self->_actions( {} );
     $self->_conditions( {} );
+    $self->_next_state( {} );
 
     # Note this is the workflow type.
     $self->type( $config->{type} );
@@ -278,6 +280,7 @@ sub _add_action_config {
             "is required -- if you do not want the state to ",
             "change, use the value '$no_change_value'.";
     }
+    $self->_next_state->{$action_name} = $action_config->{resulting_state};
     $self->log->debug("Adding '$state' '$action_name' config");
     $self->_actions->{$action_name} = $action_config;
     my @action_conditions = $self->_create_condition_objects($action_config);


### PR DESCRIPTION
# Description

Separate state's action-related data from actual Action configuration.

This solves a problem reported by @oliwel due to the 1.55 release, which confuses OpenXPKI due to the 'resulting_state' and 'condition' keys being part of the action configuration.

## Type of change

Please delete options that are not relevant.

Arguably, this is a bugfix.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

