### PR TITLE
Without preceeding `eval{}`, don't check $EVAL_ERROR

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -159,9 +159,6 @@ sub add_history {
                 ref($item), "'";
         }
 
-        if ($EVAL_ERROR) {
-            workflow_error "Unable to assert history object";
-        }
     }
     push @{ $self->{_histories} }, @to_add;
     $self->notify_observers( 'add history', \@to_add );


### PR DESCRIPTION
# Description

Since $EVAL_ERROR isn't explicitly bound to be `undef`, its
value could be a left-over value from anywhere else, which *could*
trigger an exception being thrown without there being good reason.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
