### PR TITLE
Instead of suppressing an exception, prevent it

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -81,6 +81,7 @@ Data::Dumper               = 0
 Carp                       = 0
 File::Slurp                = 0
 Data::UUID                 = 0
+Scalar::Util               = 0
 
 ; REF: Dist::Zilla https://metacpan.org/pod/Dist::Zilla
 [Prereqs / TestRequires]

--- a/lib/Workflow/Validator/MatchesDateFormat.pm
+++ b/lib/Workflow/Validator/MatchesDateFormat.pm
@@ -5,8 +5,8 @@ use strict;
 use base qw( Workflow::Validator );
 use DateTime::Format::Strptime;
 use Workflow::Exception qw( configuration_error validation_error );
-use English qw( -no_match_vars );
 use Carp qw(carp);
+use Scalar::Util qw( blessed );
 
 $Workflow::Validator::MatchesDateFormat::VERSION = '1.56';
 
@@ -34,12 +34,11 @@ sub validate {
     my ( $self, $wf, $date_string ) = @_;
     return unless ($date_string);
 
-    # already converted!
-    if ( ref $date_string and eval { $date_string->isa('DateTime'); } ) {
+    if ( blessed $date_string and $date_string->isa('DateTime') ) {
+        # already converted!
         return;
     }
-
-    if ($EVAL_ERROR) {
+    if ( ref $date_string ) { # ref but not blessed?!
         carp 'Unable to assert DateTime or similar object';
     }
 


### PR DESCRIPTION

# Description

By checking if the dereferenced value is blessed, make sure we can
call 'isa' on it. Adds dependency on `Scalar::Util` (which is in 'core').

## Type of change

Code quality improvement: don't use `eval` as `try` when not necessary...
