### PR TITLE
Restore concern boundaries for transactions

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -296,14 +296,8 @@ sub _execute_single_action {
         # the workflow; if it fails we should have some means for the
         # factory to rollback other transactions...
 
-        # Update
-        # Jim Brandt 4/16/2008: Implemented transactions for DBI persisters.
-        # Implementation still depends on each persister.
-
-        $self->_factory()->save_workflow($self);
-
-        # If using a DBI persister with no autocommit, commit here.
-        $self->_factory()->_commit_transaction($self);
+        $self->_factory()->save_workflow( $self );
+        $self->notify_observers( 'save' );
 
         $self->log->is_info
             && $self->log->info("Saved workflow with possible new state ok");
@@ -315,7 +309,7 @@ sub _execute_single_action {
         );
         $self->state($old_state);
 
-        $self->_factory()->_rollback_transaction($self);
+        $self->notify_observers( 'rollback' );
 
         # If it is a validation error we rethrow it so it can be evaluated
         # by the caller to provide better feedback to the user
@@ -844,6 +838,13 @@ No additional parameters.
 =item *
 
 B<fetch> - Issued after a workflow is fetched from the persister.
+
+No additional parameters.
+
+=item *
+
+B<rollback> - Issued after a workflow is rolled back, e.g. due to failed
+action execution.
 
 No additional parameters.
 

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -398,6 +398,7 @@ sub commit_transaction {
             $self->log->error("Caught error committing transaction: $error");
             persist_error $error;
         }
+        $self->log->debug('Committed transaction.');
     }
 }
 
@@ -411,6 +412,12 @@ sub rollback_transaction {
             $self->log->error("Caught error rolling back transaction: $error");
             persist_error $error;
         }
+        $self->log->debug('Rolled back transaction.');
+    }
+    else {
+        $self->log->warn(
+            'Transaction NOT rolled back due to "autocommit" being enabled.'
+            );
     }
 }
 

--- a/t/workflow.t
+++ b/t/workflow.t
@@ -10,7 +10,7 @@ eval "require DBI";
 if ( $@ ) {
     plan skip_all => 'DBI not installed';
 } else {
-    plan tests => 38;
+    plan tests => 33;
 }
 
 require_ok( 'Workflow' );
@@ -89,27 +89,6 @@ my @result_data   = ( 'INITIAL', $date );
         'Observation sent to configured subroutine observer second' );
     is( $observations[1]->[2], 'fetch',
         'Subroutine observer sent the correct fetch action' );
-}
-
-{
-    $handle->{mock_add_resultset} = [ \@result_fields, \@result_data ];
-    my $wf = $factory->fetch_workflow( 'ObservedTicket', 1 );
-    SomeObserver->clear_observations;
-
-    $factory->save_workflow( $wf );
-    my @observations = SomeObserver->get_observations;
-    is( scalar @observations, 2,
-        'One observation sent on workflow store to two observers' );
-
-    is( $observations[0]->[0], 'class',
-        'Observation sent to configured class observer first' );
-    is( $observations[0]->[2], 'save',
-        'Class observer sent the correct save action' );
-
-    is( $observations[1]->[0], 'sub',
-        'Observation sent to configured subroutine observer second' );
-    is( $observations[1]->[2], 'save',
-        'Subroutine observer sent the correct save action' );
 }
 
 {


### PR DESCRIPTION
# Description

Concerns to be respected:
 * Workflows notify their own observers
 * Persisters manage transactions
 * The factory knows about persisters and their API
 * Only the factory can call its own internal APIs
   (e.g. _commit_transaction and _rollback_transaction)
 * With the right observers, the factory doesn't *need* internal APIs

## Type of change

* [x] Refactoring

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
