### PR TITLE
Eliminate warning about `chdir(undef)`

### DIFF
--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -8,12 +8,6 @@ use List::MoreUtils qw(all);
 
 $VERSION = '0.02';
 
-my ( $original_dir );
-
-END {
-    chdir( $original_dir );
-}
-
 my $LOG_FILE  = 't/workflow_tests.log';
 my $CONF_FILE = 't/log4perl.conf';
 


### PR DESCRIPTION
# Description

As the title describes. Before this change Perl 5.14 has a lot of errors about `chdir(undef)` being deprecated. This PR fixes the cause of those.

