### PR TITLE
Add B::Deparse support for Syntax::Keyword::Try

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           cd build
           [ -d xt ] && prove --timer --lib --recurse --jobs $(nproc) --shuffle xt/
-          HARNESS_PERL_SWITCHES=-MDevel::Cover=+ignore,^t/ prove --timer --lib --recurse --jobs $(nproc) --shuffle t/
+          HARNESS_PERL_SWITCHES="-MDevel::Cover=+ignore,^t/ -MSyntax::Keyword::Try::Deparse" prove --timer --lib --recurse --jobs $(nproc) --shuffle t/
       - name: Report coverage info to Coveralls
         run: |
           cd build


### PR DESCRIPTION
# Description

Suppress warnings from B::Deparse by making sure Syntax::Keyword::Try::Deparse is loaded.

## Type of change

- [x] Maintenance (clean test output)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
