### PR TITLE
carp() ends up on STDOUT instead of in the logs

### DIFF
--- a/lib/Workflow/Validator/MatchesDateFormat.pm
+++ b/lib/Workflow/Validator/MatchesDateFormat.pm
@@ -6,7 +6,6 @@ use 5.006;
 use base qw( Workflow::Validator );
 use DateTime::Format::Strptime;
 use Workflow::Exception qw( configuration_error validation_error );
-use Carp qw(carp);
 use Scalar::Util qw( blessed );
 
 $Workflow::Validator::MatchesDateFormat::VERSION = '1.56';
@@ -38,9 +37,6 @@ sub validate {
     if ( blessed $date_string and $date_string->isa('DateTime') ) {
         # already converted!
         return;
-    }
-    if ( ref $date_string ) { # ref but not blessed?!
-        carp 'Unable to assert DateTime or similar object';
     }
 
     my $fmt         = $self->formatter;


### PR DESCRIPTION
# Description

By throwing a validation error, user and programmer get the appropriate feedback. `carp()` doesn't end up in the logs, so `carp`-ing doesn't add much (but pollutes the output of the test runs).

## Type of change

Please delete options that are not relevant.

- [x] Maintenance

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
