### PR TITLE
Check and update http(s) links from POD

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -37,11 +37,17 @@ on test => sub {
     requires 'DBD::Mock'             => '0.10';
     requires 'List::MoreUtils';
     requires 'Mock::MonkeyPatch';
-    requires 'Pod::Coverage::TrustPod';
     requires 'Test::Exception';
-    requires 'Test::Kwalitee'        => '1.21';
     requires 'Test::More'            => '0.88';
-    requires 'Test::Pod'             => '1.41';
-    requires 'Test::Pod::Coverage'   => '1.08';
     requires 'Test::Without::Module' => '0.20';
+};
+
+on develop => sub {
+    requires 'Test::CPAN::Meta::JSON' => '0.16'; # from Dist::Zilla
+    requires 'Test::Kwalitee'         => '1.21'; # from Dist::Zilla
+    requires 'Test::Perl::Critic'     => '1.04'; # from Dist::Zilla
+    requires 'Test::Pod'              => '1.41'; # from Dist::Zilla
+    requires 'Test::Pod::Coverage'    => '1.08'; # from Dist::Zilla
+    requires 'Pod::Coverage::TrustPod'; # ??? from Dist::Zilla
+    requires 'Test::Pod::Links'       => '0.003';
 };

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -1454,7 +1454,7 @@ able to attach event listeners (observers) to the process.
 
 Michael Roberts E<lt>michael@vivtek.comE<gt> graciously released the
 'Workflow' namespace on CPAN; check out his Workflow toolkit at
-L<http://www.vivtek.com/wftk.html>.
+L<http://www.vivtek.com/wftk/>.
 
 Michael Schwern E<lt>schwern@pobox.orgE<gt> barked via RT about a
 dependency problem and CPAN naming issue.

--- a/t/pod_links.t
+++ b/t/pod_links.t
@@ -1,0 +1,17 @@
+#!perl
+
+use 5.006;
+use strict;
+use warnings;
+
+use Test::More;
+
+if ( not exists $ENV{POD_LINKS} ) {
+    plan skip_all => 'Environment variable POD_LINKS not set';
+}
+
+require Test::Pod::Links
+    or plan skip_all => 'Test::Pod::Links not installed';
+
+
+Test::Pod::Links->new->all_pod_files_ok;


### PR DESCRIPTION
# Description

This PR was inspired by a prior PR which removed a link to the "theoryx5" site,
because the link didn't resolve. With this PR, we have the machinery to verify
all links at once.

Michael Roberts changed his site layout; adapting the link.

Also moved the "author test dependencies" to the "on develop" section of the cpanfile.

## Type of change

- [x] Maintenance

Since Dist::Zilla automatically injects on its output of `dzil authordeps` the dependencies listed with "# from Dist::Zilla", should we even list those? (Rather, they're being pulled in by the dependencies of the plugins we use.) Or, instead document how to list/install the dependencies for developers?

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
