### PR TITLE
Get the values for the initial history items from the workflow

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -1181,7 +1181,7 @@ several fields are required.
 
 =head3 get_initial_history_data
 
-This method returns a list of key/value pairs to add in the initial history
+This method returns a I<list> of key/value pairs to add in the initial history
 record. The following defaults are returned:
 
 =over
@@ -1202,7 +1202,16 @@ value: "Create workflow"
 
 =back
 
-Override this method to change the values from their defaults.
+Override this method to change the values from their defaults. E.g.
+
+
+   sub get_initial_history_data {
+      return (
+           user => 1,
+           description => "none",
+           action => "run"
+      );
+   }
 
 
 =head1 CONFIGURATION AND ENVIRONMENT

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -43,6 +43,16 @@ sub notify_observers {
     return;
 }
 
+sub get_initial_history_data {
+    my ( $self ) = @_;
+    return (
+        description => 'Create new workflow',
+        user        => 'n/a',
+        action      => 'Create workflow',
+        );
+}
+
+
 ########################################
 # PUBLIC METHODS
 
@@ -1162,6 +1172,38 @@ Assign the L<Workflow::State> object C<$wf_state> to the workflow.
 Returns the name of the next state given the action
 C<$action_name>. Throws an exception if C<$action_name> not contained
 in the current state.
+
+
+=head2 Initial workflow history
+
+When creating an initial L<Workflow::History> record when creating a workflow,
+several fields are required.
+
+=head3 get_initial_history_data
+
+This method returns a list of key/value pairs to add in the initial history
+record. The following defaults are returned:
+
+=over
+
+=item * C<user>
+
+value: "n/a"
+
+
+=item * C<description>
+
+value: "Create new workflow"
+
+=item * C<action>
+
+value: "Create workflow"
+
+
+=back
+
+Override this method to change the values from their defaults.
+
 
 =head1 CONFIGURATION AND ENVIRONMENT
 

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -351,15 +351,13 @@ sub create_workflow {
     $wf->id($id);
     $self->log->info("Persisted workflow with ID '$id'; creating history...");
     $wf->add_history(
-            {   workflow_id => $id,
-                action      => $persister->get_create_action($wf),
-                description => $persister->get_create_description($wf),
-                user        => $persister->get_create_user($wf),
-                state       => $wf->state,
-                date        => DateTime->now( time_zone => $wf->time_zone() ),
-                time_zone   => $wf->time_zone(),
-            }
-        );
+        {
+            $wf->get_initial_history_data(), # returns a *list*
+            workflow_id => $id,
+            state       => $wf->state,
+            date        => DateTime->now( time_zone => $wf->time_zone() ),
+            time_zone   => $wf->time_zone(),
+        });
     $persister->create_history( $wf, $wf->get_unsaved_history() );
     $self->log->info( "Created history object ok" );
     $persister->commit_transaction;

--- a/lib/Workflow/Persister.pm
+++ b/lib/Workflow/Persister.pm
@@ -130,21 +130,6 @@ sub fetch_history {
         "'fetch_history()'";
 }
 
-sub get_create_user {
-    my ( $self, $wf ) = @_;
-    return 'n/a';
-}
-
-sub get_create_description {
-    my ( $self, $wf ) = @_;
-    return 'Create new workflow';
-}
-
-sub get_create_action {
-    my ( $self, $wf ) = @_;
-    return 'Create workflow';
-}
-
 # Only required for DBI persisters.
 sub commit_transaction {
     return;
@@ -248,29 +233,6 @@ Persister. Since this is a SUPER class.
 The derived class method should return a list of hashes containing at least
 the `id` key. The hashes will be used by the workflow object to instantiate
 L<Workflow::History> objects (or a derived class).
-
-
-=head3 get_create_user( $workflow )
-
-When creating an initial L<Workflow::History> record to insert into the database,
-the return value of this method is used for the value of the "user" field.
-
-Override this method to change the value from the default, "n/a".
-
-=head3 get_create_description( $workflow )
-
-When creating an initial L<Workflow::History> record to insert into the database,
-the return value of this method is used for the value of the "description" field.
-
-Override this method to change the value from the default, "Create new workflow".
-
-
-=head3 get_create_action( $workflow )
-
-When creating an initial L<Workflow::History> record to insert into the database,
-the return value of this method is used for the value of the "action" field.
-
-Override this method to change the value from the default, "Create workflow".
 
 
 =head3 assign_generators( \%params )

--- a/t/TestApp/CustomWorkflow.pm
+++ b/t/TestApp/CustomWorkflow.pm
@@ -7,4 +7,13 @@ use parent qw( Workflow );
 
 $TestApp::CustomWorkflow::VERSION = '0.01';
 
+
+sub get_initial_history_data {
+    return (
+        user => 'me',
+        description => 'New workflow',
+        action => 'Create',
+    );
+}
+
 1;

--- a/t/workflow.t
+++ b/t/workflow.t
@@ -11,7 +11,7 @@ eval "require DBI";
 if ( $@ ) {
     plan skip_all => 'DBI not installed';
 } else {
-    plan tests => 36;
+    plan tests => 39;
 }
 
 require_ok( 'Workflow' );
@@ -151,6 +151,23 @@ my @result_data   = ( 'INITIAL', $date );
     like($@, qr/not found/, "expected error string: $@");
 }
 
+
+{
+    my $wf = $factory->create_workflow( 'ObservedTicket' );
+    my @history = $wf->get_history;
+    my $history = shift @history;
+
+    # Test overridden defauts:
+
+    # default: Create workflow
+    is( $history->user, 'me', "Customized user set" );
+
+    # default: n/a
+    is( $history->description, 'New workflow', "Customized description set" );
+
+    # default: Create new workflow
+    is( $history->action, 'Create', "Customized action set" );
+}
 
 
 {


### PR DESCRIPTION
# Description

Closes #34: Together with the ability to select a Workflow class, moving the responsibility
to return settings for the initial history record away from the Persister, the three fields

 * action
 * user
 * description

are effectively configurable.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
