### PR TITLE
Allow user-selectable history class

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -158,7 +158,7 @@ sub add_history {
             push @to_add, $item;
             $self->log->debug("Adding history object directly");
         } else {
-            workflow_error "I don't know how to add a history of ", "type '",
+            workflow_error "I don't know how to add a history of type '",
                 ref($item), "'";
         }
 
@@ -400,8 +400,8 @@ This documentation describes version 1.56 of Workflow
 
  <workflow>
      <type>myworkflow</type>
-     <time_zone>local</time_zone>                    <!-- optional -->
-     <description>This is my workflow.</description> <!-- optional -->
+     <time_zone>local</time_zone>                         <!-- optional -->
+     <description>This is my workflow.</description>      <!-- optional -->
      <history_class>My::Workflow::History</history_class> <!-- optional -->
 
      <state name="INITIAL">

--- a/lib/Workflow/History.pm
+++ b/lib/Workflow/History.pm
@@ -108,17 +108,18 @@ C<\%params>.
 =head3 set_new_state( $new_state )
 
 Assigns the new state C<$new_state> to the history if the state is not
-already assigned. This is used when you generate a history request in
+already assigned. This is used when you
+L<generate a history request|Workflow/add_history> in
 a L<Workflow::Action> since the workflow state will change once the
-action has successfully completed. So in the action you create a
-history object without the state:
+action has successfully completed. So in the action you create
+history without the state:
 
   $wf->add_history(
-      Workflow::History->new({
+      {
           action      => "Cocoa Puffs",
           description => "They're magically delicious",
           user        => "Count Chocula",
-      })
+      }
   );
 
 And then after the new state has been set but before the history

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -799,8 +799,6 @@ Returns nothing
 
 =item L<Workflow::Persister>
 
-=item L<Workflow::History>
-
 =item L<DBI>
 
 =back

--- a/t/TestApp/Action/TicketComment.pm
+++ b/t/TestApp/Action/TicketComment.pm
@@ -21,11 +21,11 @@ sub execute {
     $log->info( "Entering comment for workflow ", $wf->id );
 
     $wf->add_history(
-        Workflow::History->new({
+        {
             action      => "Ticket comment",
             description => $wf->context->param( 'comment' ),
             user        => $wf->context->param( 'current_user' ),
-        })
+        }
     );
 }
 

--- a/t/TestApp/Action/TicketCreate.pm
+++ b/t/TestApp/Action/TicketCreate.pm
@@ -70,12 +70,12 @@ sub execute {
     $log->info( "Link table record inserted correctly" );
 
     $wf->add_history(
-        Workflow::History->new({
+        {
             action      => 'Create ticket',
             description => sprintf( "New ticket created of type '%s' and subject '%s'",
                                     $self->param( 'type' ), $self->param( 'subject' ) ),
             user        => $creator,
-        })
+        }
     );
     $log->info( "History record added to workflow ok" );
 }

--- a/t/TestApp/Action/TicketCreateType.pm
+++ b/t/TestApp/Action/TicketCreateType.pm
@@ -70,12 +70,12 @@ sub execute {
     $log->info( "Link table record inserted correctly" );
 
     $wf->add_history(
-        Workflow::History->new({
+        {
             action      => 'Create ticket',
             description => sprintf( "New ticket created of type '%s' and subject '%s'",
                                     $self->param( 'type' ), $self->param( 'subject' ) ),
             user        => $creator,
-        })
+        }
     );
     $log->info( "History record added to workflow ok" );
 }

--- a/t/TestApp/CustomWorkflowHistory.pm
+++ b/t/TestApp/CustomWorkflowHistory.pm
@@ -1,0 +1,10 @@
+package TestApp::CustomWorkflowHistory;
+
+use warnings;
+use strict;
+use 5.006;
+use parent qw( Workflow::History );
+
+$TestApp::CustomWorkflow::VERSION = '0.01';
+
+1;

--- a/t/workflow.xml
+++ b/t/workflow.xml
@@ -1,5 +1,6 @@
 <workflow>
  <type>Ticket</type>
+ <history_class>TestApp::CustomWorkflowHistory</history_class>
  <description>This is the workflow for sample application Ticket</description>
  <persister>TestPersister</persister>
  <state name="INITIAL">


### PR DESCRIPTION
# Description

Closes #106. Moves the responsibility of instantiating history classes from the factory
and the persister into the Workflow class.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
