### PR TITLE
Don't log from `use Workflow::Factory qw( FACTORY );`

### DIFF
--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -20,17 +20,13 @@ sub import {
 
     $class = ref $class || $class;    # just in case
     my $package = caller;
-    my $log = get_logger(__PACKAGE__);
     if ( defined $_[0] && $_[0] eq 'FACTORY' ) {
-        $log->debug( "Trying to import 'FACTORY' of type '$class' to '$package'" );
         shift;
         my $instance = _initialize_instance($class);
 
         my $import_target = $package . '::FACTORY';
         no strict 'refs';
         unless ( defined &{$import_target} ) {
-            $log->debug( "Target '$import_target' not yet defined, ",
-                         "creating subroutine on the fly" );
             *{$import_target} = sub { return $instance };
         }
         return $instance;


### PR DESCRIPTION
# Description

Logging during import breaks the generally accepted convention
of using modules and *then* doing all the work, like initialization.

Logging during import() is simply 'too early' and causes truckloads of "Log4perl not initialized" warnings in LedgerSMB.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
