### PR TITLE
Delay instantiation to prevent further logging attempts

### DIFF
--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -23,14 +23,17 @@ sub import {
     my $log = get_logger(__PACKAGE__);
     if ( defined $_[0] && $_[0] eq 'FACTORY' ) {
         shift;
-        my $instance = _initialize_instance($class);
+        my $instance;
 
         my $import_target = $package . '::FACTORY';
         no strict 'refs';
         unless ( defined &{$import_target} ) {
-            *{$import_target} = sub { return $instance };
+            *{$import_target} = sub {
+                return $instance if $instance;
+                $instance = _initialize_instance($class);
+                return $instance;
+            };
         }
-        return $instance;
     }
     $class->SUPER::import(@_);
 }

--- a/t/factory.t
+++ b/t/factory.t
@@ -3,7 +3,7 @@
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;
-use Test::More  tests => 7;
+use Test::More  tests => 6;
 use Test::Exception;
 
 require_ok( 'Workflow::Factory' );
@@ -17,10 +17,6 @@ is( $other_factory, $factory,
 my $factory_new = eval { Workflow::Factory->new() };
 is( ref( $@ ), 'Workflow::Exception',
     'Call to new() throws proper exception' );
-
-my $i_factory = Workflow::Factory->import( 'FACTORY' );
-is( $i_factory, $factory,
-    'Imported factory returns the same object' );
 
 lives_ok { $factory->add_config_from_file( workflow  => 'workflow.xml',
                                     action    => [ 'workflow_action.xml', 'workflow_action_type.xml', 'workflow_action.perl',  ],

--- a/t/factory_subclass.t
+++ b/t/factory_subclass.t
@@ -3,7 +3,7 @@
 use strict;
 use lib qw(../lib lib ../t t);
 use TestUtil;
-use Test::More  tests => 5;
+use Test::More  tests => 4;
 
 require_ok( 'FactorySubclass' );
 my $factory = FactorySubclass->instance();
@@ -15,8 +15,4 @@ is( $other_factory, $factory,
 my $factory_new = eval { FactorySubclass->new() };
 is( ref( $@ ), 'Workflow::Exception',
     'Call to new() throws proper exception' );
-
-my $i_factory = FactorySubclass->import( 'FACTORY' );
-is( $i_factory, $factory,
-    'Imported factory returns the same object' );
 


### PR DESCRIPTION
# Description

Note that this commit changes 'import()' in the sense that it no
longer returns the instance. However, there's no documentation that
it should.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
