### PR TITLE
Addressed Perl::Critic policy violation of ValuesAndExpressions::ProhibitMixedBooleanOperators

### DIFF
--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -219,7 +219,7 @@ sub _assign_next_state_from_array {
     my @errors        = ();
     my %new_resulting = ();
     foreach my $map ( @{$resulting} ) {
-        if ( !$map->{state} or !defined $map->{return} ) {
+        if ( not $map->{state} or not defined $map->{return} ) {
             push @errors,
                 "Must have both 'state' ($map->{state}) and 'return' "
                 . "($map->{return}) keys defined.";


### PR DESCRIPTION
# Description

Please include a summary of the proposed improvement or addressed issue.

Fixes/addresses (If applicable) a violation of a Perl::Critic policy

REF: https://metacpan.org/pod/Perl::Critic::Policy::ValuesAndExpressions::ProhibitMixedBooleanOperators

## Type of change

Please delete options that are not relevant.

. [x] This is a maintenance/coding style change

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
