### PR TITLE
Document persister's handling of workflow context

### DIFF
--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -398,7 +398,7 @@ sub fetch_workflow {
     my $wf = $wf_class->new( $wf_id, $wf_info->{state}, $wf_config,
         $self->{_workflow_state}{$wf_type}, $self );
 
-    $wf->context( $wf_info->{context} || Workflow::Context->new ); #if ( not $wf->context() );
+    $wf->context( Workflow::Context->new(%{ $wf_info->{context} // {} }) );
     $wf->last_update( $wf_info->{last_update} );
 
     $persister->fetch_extra_workflow_data($wf);

--- a/lib/Workflow/Persister.pm
+++ b/lib/Workflow/Persister.pm
@@ -202,7 +202,8 @@ Returns the ID for the workflow.
 Stub that warns that the method should be overwritten in the derived
 Persister. Since this is a SUPER class.
 
-Update the workflow state.
+Update the workflow state including serialization of the workflow
+context.
 
 Returns nothing.
 
@@ -214,6 +215,11 @@ Persister. Since this is a SUPER class.
 Retrieve the workflow data corresponding to C<$workflow_id>. It not
 found return undef, if found return a hashref with at least the keys
 C<state> and C<last_update> (a L<DateTime> instance).
+
+If the workflow has associated serialized context, return the
+deserialized hash value in the C<context> key.  The keys in the hash
+will be made available through the C<param> method in the workflow's
+context (accessible through the C<context> method).
 
 =head3 create_history( $workflow, @history )
 

--- a/lib/Workflow/Persister/File.pm
+++ b/lib/Workflow/Persister/File.pm
@@ -128,8 +128,7 @@ sub _serialize_workflow {
         state       => $wf->state,
         last_update => $wf->last_update,
         type        => $wf->type,
-        context     => $wf->context,
-
+        context     => { %{$wf->context->{PARAMS} } },
     );
     $self->serialize_object( $full_path, \%wf_info );
     $self->log->debug("Wrote workflow ok");


### PR DESCRIPTION
# Description

Document that the serializer is expected to persist the `context` as well as the immediate workflow state. I'm explicitly declaring that it's **not** the Context instance which is to be returned, because that creates a tight coupling between the persister and the context class it will use. At a later stage, the Factory can be used to associate different Context classes with workflows.

Also, update the File persister to persist the workflow's Context according to the declared protocol.


**Note**: we probably needs something similar in the DBI serializer?

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Marking as 2.0, because this breaks older serializations: When a Context object was returned from the persister, the new context being instantiated by the Factory receives the content of the blessed Context hash instead of the PARAMS hash.

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
