### PR TITLE
Correction to Perl::Critic configuration

### DIFF
--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -14,6 +14,7 @@ script_sections = NAME|DESCRIPTION|SYNOPSIS|AUTHORS|COPYRIGHT
 
 # REF: https://metacpan.org/pod/Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers
 [ValuesAndExpressions::ProhibitMagicNumbers]
+allowed_values = 0 1 2 3 4 5 6
 
 # Might be to late to address, so it is disabled at various places in the code, could perhaps be 
 # revisited with a major release, since it would break backwards compatibility, the recommeded 
@@ -37,7 +38,6 @@ script_sections = NAME|DESCRIPTION|SYNOPSIS|AUTHORS|COPYRIGHT
 # For embedded SQL this is perfectly ok
 # REF: https://metacpan.org/pod/Perl::Critic::Policy::ValuesAndExpressions::ProhibitImplicitNewlines
 [ValuesAndExpressions::ProhibitImplicitNewlines]
-allowed_values = 0 1 2 3 4 5 6
 
 # Exchange for Module::Load or Module::Runtime?
 # REF: https://metacpan.org/pod/Perl::Critic::Policy::BuiltinFunctions::ProhibitStringyEval


### PR DESCRIPTION
# Description

The test suite emits a warning

> The ValuesAndExpressions::ProhibitImplicitNewlines policy doesn't take a "allowed_values" option.

The options are placed under:

Perl::Critic::Policy::ValuesAndExpressions::ProhibitImplicitNewlines

But should be under:

Perl::Critic::Policy::ValuesAndExpressions::ProhibitMagicNumbers

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
