### PR TITLE
Add restricting action execution on 'auto run' state

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -12,7 +12,7 @@ use Carp qw(croak carp);
 use Syntax::Keyword::Try;
 
 my @FIELDS   = qw( id type description state last_update time_zone
-    history_class );
+    history_class autorun );
 my @INTERNAL = qw( _factory _observers );
 __PACKAGE__->mk_accessors( @FIELDS, @INTERNAL );
 
@@ -237,6 +237,7 @@ sub init {
     );
 
     $self->id($id) if ($id);
+    $self->autorun(''); # initialize to false
     $self->_factory($factory);
 
     $self->state($current_state);
@@ -283,6 +284,7 @@ sub _execute_single_action {
 
     # This checks the conditions behind the scenes, so there's no
     # explicit 'check conditions' step here
+    local $self->{autorun} = $autorun;
     my $action = $self->get_action($action_name);
 
     # Need this in case we encounter an exception after we store the

--- a/lib/Workflow/Condition/Autorun.pm
+++ b/lib/Workflow/Condition/Autorun.pm
@@ -1,0 +1,73 @@
+package Workflow::Condition::Autorun;
+
+use warnings;
+use strict;
+use v5.14.0;
+
+our $VERSION = '1.57';
+
+use parent qw( Workflow::Condition );
+
+sub evaluate {
+    my ($self, $wf) = @_;
+    return $wf->autorun;
+}
+
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Workflow::Condition::Autorun - Condition evaluation in 'autorun' context
+
+=head1 VERSION
+
+This documentation describes version 1.57 of this package
+
+=head1 DESCRIPTION
+
+This condition can be used to include (or exclude, when negated) actions
+from workflow execution; e.g. to make sure an action can only be triggered
+outside of autorun state.
+
+=head1 SYNOPSIS
+
+In condition.xml:
+
+    <condition name="is_autorun" class="Workflow::Condition::Autorun" />
+
+In workflow.xml:
+
+    <state name="CHECK_APPROVALS" autorun="yes">
+        <action name="null_1" resulting_state="APPROVED">
+            <condition name="!is_autorun" />
+        </action>
+        <action name="notify-check" resulting_state="AWAITING_APPROVAL">
+            <condition name="is_autorun" />
+        </action>
+    </state>
+
+=cut
+
+=head1 AUTHORS
+
+See L<Workflow>
+
+=head1 COPYRIGHT
+
+Copyright (c) 2004-2021 Chris Winters. All rights reserved.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+Please see the F<LICENSE>
+
+=head1 AUTHORS
+
+Please see L<Workflow>
+
+=cut

--- a/t/workflow_autorun.xml
+++ b/t/workflow_autorun.xml
@@ -6,7 +6,12 @@
    <action name="enter" resulting_state="ENTERED"/>
  </state>
  <state name="ENTERED" autorun="yes">
-   <action name="progress" resulting_state="IN PROGRESS" />
+   <action name="progress" resulting_state="IN PROGRESS">
+     <condition name="!is_autorun" />
+   </action>
+   <action name="finish" resulting_state="FINISHED">
+     <condition name="!is_autorun" />
+   </action>
  </state>
  <state name="IN PROGRESS">
    <action name="finish" resulting_state="FINISHED" />

--- a/t/workflow_autorun_condition.xml
+++ b/t/workflow_autorun_condition.xml
@@ -1,0 +1,4 @@
+<conditions>
+  <condition name="is_autorun"
+             class="Workflow::Condition::Autorun" />
+</conditions>


### PR DESCRIPTION
# Description

In case an action wants to be excluded from autorunning, or *only*
wants to be available when autorunning, this can't be expressed
with the current available conditions. This PR adds a condition
(with support from the workflow object) which allows this distinction.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
