### PR TITLE
Add Perl 5.34 to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        perl: [ "5.14", "5.20", "5.26", "5.30" ]
+        perl: [ "5.14", "5.20", "5.30", "5.34" ]
     name: linux ${{ matrix.perl }}
 
 


### PR DESCRIPTION
# Description

Add Perl 5.34 to the suite of tested Perl versions.

## Type of change

Please delete options that are not relevant.

- [x] Infrastructure

# Checklist:

