### PR TITLE
Document that Workflow::Validator is an interface contract

### DIFF
--- a/lib/Workflow/Validator/InEnumeratedType.pm
+++ b/lib/Workflow/Validator/InEnumeratedType.pm
@@ -8,8 +8,9 @@ use Workflow::Exception qw( configuration_error validation_error );
 
 $Workflow::Validator::InEnumeratedType::VERSION = '1.57';
 
-sub _init {
+sub init {
     my ( $self, $params ) = @_;
+    $self->SUPER::init( $params );
     $self->{_enum}       = [];
     $self->{_enum_match} = {};
     unless ( $params->{value} ) {

--- a/lib/Workflow/Validator/MatchesDateFormat.pm
+++ b/lib/Workflow/Validator/MatchesDateFormat.pm
@@ -12,8 +12,9 @@ $Workflow::Validator::MatchesDateFormat::VERSION = '1.57';
 
 __PACKAGE__->mk_accessors('formatter');
 
-sub _init {
+sub init {
     my ( $self, $params ) = @_;
+    $self->SUPER::init( $params );
     unless ( $params->{date_format} ) {
         configuration_error "You must define a value for 'date_format' in ",
             "declaration of validator ", $self->name;


### PR DESCRIPTION
# Description

Declaring the Workflow::Validator an interface contract as opposed to a
base class for validators allows *any* class to implement validations. This
addresses a long-standing desire of the OpenXPKI project to consolidate
the Condition and Validator concepts - in order to be able to share code
between the two - without actually consolidating them.

Closes #137

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change

This is really meant to be a documentation-only change. However, it didn't actually pan out that way, because of removing both the documentation and implementation of the `_init()` method: there's no place for a "dummy" method in an interface definition. Also, it doesn't make sense from an OOP perspective to have that method. Instead, a newly declared `init()` method should be calling its parent's `init()` as with regular OOP patterns.

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

This is a good point: should we add tests which implement a validator as a blessed ref *not* derived from `Workflow::Validator` or `Workflow::Base`?
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
