### PR TITLE
Enforce call to context->param as scalar

### DIFF
--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -80,7 +80,7 @@ sub validate {
         my @runtime_args = ($wf);
         foreach my $arg ( @{$args} ) {
             if ( $arg =~ /^\$(.*)$/ ) {
-                push @runtime_args, $context->param($1);
+                push @runtime_args, scalar $context->param($1);
             } else {
                 push @runtime_args, $arg;
             }


### PR DESCRIPTION
# Description

When a parameter given in the argument list of a validator does
not exist this is evaluated as list context and the empty list
does not change the runtime_args with the consequence that the
position of the arguments changes in the list, breaking the
functionality of the validator.

This is a follow up to the problem fixed by #195

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
