### PR TITLE
Change Workflow::History SYNOPSIS

### DIFF
--- a/lib/Workflow/History.pm
+++ b/lib/Workflow/History.pm
@@ -76,9 +76,12 @@ This documentation describes version 1.57 of this package
      my ( $self, $wf ) = @_;
      my $current_user = $wf->context->param( 'current_user' );
      # ... do your work with $ticket
-     $wf->add_history( action => 'create ticket',
-                       user   => $current_user->full_name,
-                       description => "Ticket $ticket->{subject} successfully created" );
+     $wf->add_history(
+         {
+            action => 'create ticket',
+            user   => $current_user->full_name,
+            description => "Ticket $ticket->{subject} successfully created"
+         });
  }
 
  # in your view (using TT2)


### PR DESCRIPTION
# Description

The old description isn't aligned with the description of the API of the
 `add_history` method on the `Workflow` instance.

## Type of change

Please delete options that are not relevant.

- [x] This change *is* a documentation update

