### PR TITLE
Action args

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -296,10 +296,7 @@ sub _execute_single_action {
         $self->log->is_debug && $self->log->debug("Action validated ok");
         if ($action_args) {
             # Merge the action args into the context
-            my $ctx = $self->context;
-            while (my ($k, $v) = each %{$action_args}) {
-                $ctx->param( $k, $v );
-            }
+            $self->context->param( $action_args );
         }
         $action_return = $action->execute($self);
         $self->log->is_debug && $self->log->debug("Action executed ok");

--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -113,11 +113,11 @@ sub get_action_fields {
 }
 
 sub execute_action {
-    my ( $self, $action_name, $autorun ) = @_;
+    my ( $self, $action_name ) = @_;
 
     while ( $action_name ) {
         my $wf_state =
-            $self->_execute_single_action( $action_name, $autorun );
+            $self->_execute_single_action( $action_name );
 
         if ( not $wf_state->autorun ) {
             last;
@@ -279,7 +279,7 @@ sub set {
 
 
 sub _execute_single_action {
-    my ( $self, $action_name, $autorun ) = @_;
+    my ( $self, $action_name ) = @_;
 
     # This checks the conditions behind the scenes, so there's no
     # explicit 'check conditions' step here
@@ -336,12 +336,11 @@ sub _execute_single_action {
         croak $error;
     }
 
-    $self->notify_observers( 'execute', $old_state, $action_name, $autorun );
+    $self->notify_observers( 'execute', $old_state, $action_name );
 
     my $new_state_obj = $self->_get_workflow_state;
     if ( $old_state ne $new_state ) {
-        $self->notify_observers( 'state change', $old_state, $action_name,
-            $autorun );
+        $self->notify_observers( 'state change', $old_state, $action_name );
     }
 
     return $new_state_obj;
@@ -873,11 +872,9 @@ No additional parameters.
 B<execute> - Issued after a workflow is successfully executed and
 saved.
 
-Adds the parameters C<$old_state>, C<$action_name> and C<$autorun>.
+Adds the parameters C<$old_state>, and C<$action_name>.
 C<$old_state> includes the state of the workflow before the action
-was executed, C<$action_name> is the action name that was executed and
-C<$autorun> is set to 1 if the action just executed was started
-using autorun.
+was executed, C<$action_name> is the action name that was executed.
 
 =item *
 
@@ -885,10 +882,9 @@ B<state change> - Issued after a workflow is successfully executed,
 saved and results in a state change. The event will not be fired if
 you executed an action that did not result in a state change.
 
-Adds the parameters C<$old_state>, C<$action> and C<$autorun>.
+Adds the parameters C<$old_state>, and C<$action>.
 C<$old_state> includes the state of the workflow before the action
-was executed, C<$action> is the action name that was executed and
-C<$autorun> is set to 1 if the action just executed was autorun.
+was executed, C<$action> is the action name that was executed.
 
 =item *
 
@@ -935,13 +931,12 @@ than the entire system.
 
 =head2 Object Methods
 
-=head3 execute_action( $action_name, $autorun )
+=head3 execute_action( $action_name )
 
 Execute the action C<$action_name>. Typically this changes the state
 of the workflow. If C<$action_name> is not in the current state, fails
 one of the conditions on the action, or fails one of the validators on
-the action an exception is thrown. $autorun is used internally and
-is set to 1 if the action was executed using autorun.
+the action an exception is thrown.
 
 After the action has been successfully executed and the workflow saved
 we issue a 'execute' observation with the old state, action name and
@@ -950,7 +945,7 @@ So if you wanted to write an observer you could create a
 method with the signature:
 
  sub update {
-     my ( $class, $workflow, $action, $old_state, $action_name, $autorun )
+     my ( $class, $workflow, $action, $old_state, $action_name )
         = @_;
      if ( $action eq 'execute' ) { .... }
  }

--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -66,7 +66,7 @@ sub get_validators {
 }
 
 sub validate {
-    my ( $self, $wf ) = @_;
+    my ( $self, $wf, $action_args ) = @_;
     my @validators = $self->get_validators;
     return unless ( scalar @validators );
 
@@ -75,17 +75,15 @@ sub validate {
         my $validator    = $validator_info->{validator};
         my $args         = $validator_info->{args};
 
-        # TODO: Revisit this statement it does not look right
-        # runtime_args becomes the WF object??
-        my @runtime_args = ($wf);
+        my @runtime_args = ();
         foreach my $arg ( @{$args} ) {
             if ( $arg =~ /^\$(.*)$/ ) {
-                push @runtime_args, $context->param($1);
+                push @runtime_args, $action_args->{$1};
             } else {
                 push @runtime_args, $arg;
             }
         }
-        $validator->validate(@runtime_args);
+        $validator->validate($wf, @runtime_args);
     }
 }
 
@@ -460,9 +458,10 @@ L<Workflow::Validator> object, while 'args' contains an arrayref of
 arguments to pass to the validator, some of which may need to be
 evaluated at runtime.
 
-=head3 validate( $workflow )
+=head3 validate( $workflow, $action_args )
 
-Run through all validators for this action. If any fail they will
+Run through all validators for this action, using the arguments
+provided with the C<execute_action> call. If any fail they will
 throw a L<Workflow::Exception>, the validation subclass.
 
 =head3 execute( $workflow )

--- a/lib/Workflow/Action.pm
+++ b/lib/Workflow/Action.pm
@@ -70,7 +70,11 @@ sub validate {
     my @validators = $self->get_validators;
     return unless ( scalar @validators );
 
-    my $context = $wf->context;
+    $action_args //= {};
+    my %all_args = (
+        %{ $wf->context->param() },
+        %{$action_args}
+        );
     foreach my $validator_info (@validators) {
         my $validator    = $validator_info->{validator};
         my $args         = $validator_info->{args};
@@ -78,7 +82,7 @@ sub validate {
         my @runtime_args = ();
         foreach my $arg ( @{$args} ) {
             if ( $arg =~ /^\$(.*)$/ ) {
-                push @runtime_args, $action_args->{$1};
+                push @runtime_args, $all_args{$1};
             } else {
                 push @runtime_args, $arg;
             }

--- a/lib/Workflow/Base.pm
+++ b/lib/Workflow/Base.pm
@@ -38,7 +38,12 @@ sub param {
 
     if ( ref $name eq 'HASH' ) {
         foreach my $param_name ( keys %{$name} ) {
-            $self->{PARAMS}{$param_name} = $name->{$param_name};
+            if (defined $name->{$param_name}) {
+                $self->{PARAMS}{$param_name} = $name->{$param_name};
+            }
+            else {
+                delete $self->{PARAMS}->{$param_name};
+            }
         }
         return { %{ $self->{PARAMS} } };
     }


### PR DESCRIPTION
# Description

Do not manipulate the context directly; instead, pass parameters to `execute_action`, which modifies the context *after* validating the parameters.

This has two benefits:
1. The context does not get modified when the validators fail
2. It makes the context much more an internal "scratchpad" for the workflow rather than an API

Credits of the design: @oliwel 

# For discussion

@jonasbn @oliwel 

One problem of this PR is that the context is not fully moved to being a scratchpad; it's still a read-only API: Anything other than the "current state" and "currently available next actions" should still be read from the context.

Another problem that I see, is that the parameters aren't passed to the action's `execute` method, but copied into the context directly. If we want the context to be a scratchpad for the workflow, I'd make it the responsibility of actions to read/write the context: that way it's a fully private resource.


## Type of change

- [x] Change (fix or feature that would cause existing functionality to not work as expected)
This change *should* not break existing behaviour.


# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
