### PR TITLE
Remove a misleading error condition

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -208,10 +208,6 @@ sub add_history {
             workflow_error "I don't know how to add a history of ", "type '",
                 ref($item), "'";
         }
-
-        if ($EVAL_ERROR) {
-            workflow_error "Unable to assert history object";
-        }
     }
     push @{ $self->{_histories} }, @to_add;
     $self->notify_observers( 'add history', \@to_add );


### PR DESCRIPTION
# Description

The removed lines are not related to any local code and will catch up an EVAL_ERROR set inside the caller context of add_history causing this to fail with an error where it must not

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
