### PR TITLE
Feature/independent observers

### DIFF
--- a/lib/Workflow/Config.pm
+++ b/lib/Workflow/Config.pm
@@ -14,6 +14,7 @@ $Workflow::Config::VERSION = '1.57';
 my %VALID_TYPES = (
     action    => 'actions',
     condition => 'conditions',
+    observer => 'observers',
     persister => 'persister',
     validator => 'validators',
     workflow  => 'workflow',
@@ -346,6 +347,12 @@ multiple 'action' declarations
 each 'action' declaration holds 'name' and 'resulting_state' keys and
 may hold a 'condition' key with one or more named conditions
 
+=item *
+
+each 'observer' names either a C<sub> or a C<class>. The C<sub> should
+have a package prefix (C<Package::subname>). When a C<class> name is
+given, the C<update> sub is called as a class method in the given C<class>.
+
 =back
 
 =head2 condition
@@ -490,6 +497,35 @@ take preference over random IDs
 =back
 
 For documentation of the other keys, please refer to the respective classes.
+
+=head2 observer
+
+ observers:
+
+   observer \@
+     name       $
+     type       $
+     sub        $
+     class      $
+
+=over 4
+
+=item *
+
+C<name> specifies the name of the observer for debugging purposes.
+
+=item *
+
+C<type> names the type of workflow to apply the observer to. The default
+value is C<default>.
+
+=item *
+
+The C<sub> and C<class> values have the same specification as given for
+the workflow observer keys.
+
+=back
+
 
 =head1 COPYRIGHT
 

--- a/lib/Workflow/Config/XML.pm
+++ b/lib/Workflow/Config/XML.pm
@@ -37,6 +37,10 @@ my %XML_OPTIONS = (
         ],
         KeyAttr => [],
     },
+    observer => {
+        ForceArray => [ 'observer' ],
+        KeyAttr => [],
+    }
 );
 
 my $XML_REQUIRED = 0;

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -100,6 +100,31 @@ sub _delete_instance {
 
 my %CONFIG = ( 'Workflow::Config' => 1 );
 
+sub _add_config_from_files {
+    my ($self, $method, $type, $config) = @_;
+
+    foreach my $item ( @{ $config } ) {
+        $self->$method(
+            Workflow::Config->parse_all_files( $type, $item )
+            );
+    }
+
+    return;
+}
+
+sub _add_config_from_file {
+    my ($self, $method, $type, $config) = @_;
+
+    if ( ref $config eq 'ARRAY' ) {
+        $self->_add_config_from_files( $method, $type, $config );
+    }
+    else {
+        $self->_add_config_from_files( $method, $type, [ $config ] );
+    }
+
+    return;
+}
+
 sub add_config_from_file {
     my ( $self, %params ) = @_;
     return unless ( scalar keys %params );
@@ -113,79 +138,24 @@ sub add_config_from_file {
     }
 
     $self->log->debug( "Adding condition configurations..." );
-
-    if ( ref $params{condition} eq 'ARRAY' ) {
-        foreach my $condition ( @{ $params{condition} } ) {
-            $self->_add_condition_config(
-                Workflow::Config->parse_all_files( 'condition', $condition )
-            );
-        }
-    } else {
-        $self->_add_condition_config(
-            Workflow::Config->parse_all_files(
-                'condition', $params{condition}
-            )
-        );
-    }
+    $self->_add_config_from_file( \&_add_condition_config,
+                                  'condition', $params{condition});
 
     $self->log->debug( "Adding validator configurations..." );
-
-    if ( ref $params{validator} eq 'ARRAY' ) {
-        foreach my $validator ( @{ $params{validator} } ) {
-            $self->_add_validator_config(
-                Workflow::Config->parse_all_files( 'validator', $validator )
-            );
-        }
-    } else {
-        $self->_add_validator_config(
-            Workflow::Config->parse_all_files(
-                'validator', $params{validator}
-            )
-        );
-    }
+    $self->_add_config_from_file( \&_add_validator_config,
+                                  'validator', $params{validator});
 
     $self->log->debug( "Adding persister configurations..." );
-
-    if ( ref $params{persister} eq 'ARRAY' ) {
-        foreach my $persister ( @{ $params{persister} } ) {
-            $self->_add_persister_config(
-                Workflow::Config->parse_all_files( 'persister', $persister )
-            );
-        }
-    } else {
-        $self->_add_persister_config(
-            Workflow::Config->parse_all_files(
-                'persister', $params{persister}
-            )
-        );
-    }
+    $self->_add_config_from_file( \&_add_persister_config,
+                                  'persister', $params{persister});
 
     $self->log->debug( "Adding action configurations..." );
-
-    if ( ref $params{action} eq 'ARRAY' ) {
-        foreach my $action ( @{ $params{action} } ) {
-            $self->_add_action_config(
-                Workflow::Config->parse_all_files( 'action', $action ) );
-        }
-    } else {
-        $self->_add_action_config(
-            Workflow::Config->parse_all_files( 'action', $params{action} ) );
-    }
+    $self->_add_config_from_file( \&_add_action_config,
+                                  'action', $params{action});
 
     $self->log->debug( "Adding workflow configurations..." );
-
-    if ( ref $params{workflow} eq 'ARRAY' ) {
-        foreach my $workflow ( @{ $params{workflow} } ) {
-            $self->_add_workflow_config(
-                Workflow::Config->parse_all_files( 'workflow', $workflow ) );
-        }
-    } else {
-        $self->_add_workflow_config(
-            Workflow::Config->parse_all_files(
-                'workflow', $params{workflow}
-            )
-        );
-    }
+    $self->_add_config_from_file( \&_add_workflow_config,
+                                  'workflow', $params{workflow});
 
     return;
 }

--- a/t/workflow_independent_observers.perl
+++ b/t/workflow_independent_observers.perl
@@ -1,0 +1,12 @@
+$VAR1 = {
+    observer => [
+        {
+            type => "Ticket",
+            class => "SomeObserver"
+        },
+        {
+            type => "Ticket",
+            sub => "SobeObserver::other_sub"
+        }
+        ]
+};

--- a/t/workflow_independent_observers.xml
+++ b/t/workflow_independent_observers.xml
@@ -1,0 +1,4 @@
+<observers>
+  <observer type="Ticket" class="SomeObserver" />
+  <observer type="Ticket" sub="SomeObserver::other_sub" />
+</observers>

--- a/t/workflow_observer.t
+++ b/t/workflow_observer.t
@@ -1,0 +1,149 @@
+#!/usr/bin/env perl
+
+use strict;
+use lib qw(t);
+use TestUtil;
+use Test::More;
+use Test::Exception;
+use TestApp::CustomWorkflowHistory;
+
+eval "require DBI";
+if ( $@ ) {
+    plan skip_all => 'DBI not installed';
+} else {
+    plan tests => 33;
+}
+
+require_ok( 'Workflow' );
+
+my $factory = TestUtil->init_factory();
+TestUtil->init_mock_persister();
+
+my $persister = $factory->get_persister( 'TestPersister' );
+my $handle = $persister->handle;
+
+# add a separate configuration for the observed workflow
+
+eval {
+    $factory->add_config_from_file( workflow => 't/workflow.xml',
+                                    observer => 't/workflow_independent_observers.xml' )
+};
+$@ && diag( "Error: $@" );
+ok( ! $@, "Added configuration for workflow with observer" );
+
+{
+    SomeObserver->clear_observations;
+    my $wf = $factory->create_workflow( 'Ticket' );
+    ok( $wf->isa( 'Workflow' ),
+        'Instantiated workflow is of expected type Workflow' );
+    my @observations = SomeObserver->get_observations;
+    is( scalar @observations, 2,
+        'One observation sent on workflow create to two observers' );
+
+    is( $observations[0]->[0], 'class',
+        'Observation sent to configured class observer first' );
+    is( $observations[0]->[2], 'create',
+        'Class observer sent the correct create action' );
+
+    is( $observations[1]->[0], 'sub',
+        'Observation sent to configured subroutine observer second' );
+    is( $observations[1]->[2], 'create',
+        'Subroutine observer sent the correct create action' );
+}
+
+my $date = DateTime->now;
+my @result_fields = ( 'state',   'last_update' );
+my @result_data   = ( 'INITIAL', $date );
+
+# Check object data.
+{
+  $handle->{mock_add_resultset} = [ \@result_fields, \@result_data ];
+
+  my $wf = $factory->fetch_workflow( 'Ticket', 1 );
+  is( $wf->type(), 'Ticket', 'Got workflow type.');
+  is( $wf->description(),
+      'This is the workflow for sample application Ticket',
+      'Got workflow description.');
+  is( $wf->time_zone(), 'floating', 'Got floating time zone.');
+}
+
+{
+    SomeObserver->clear_observations;
+
+    #The order of these statements are important, see RT #53909
+    #https://rt.cpan.org/Ticket/Display.html?id=53909
+    #So this is a temp work around since, the actual perl issue highlighted here
+    #seem to be fixed in blead (See: Changes file)
+    $handle->{mock_add_resultset} = [ \@result_fields, \@result_data ];
+
+    my $wf = $factory->fetch_workflow( 'Ticket', 1 );
+    my @observations = SomeObserver->get_observations;
+
+    is( scalar @observations, 2,
+        'One observation sent on workflow fetch to two observers' );
+
+    is( $observations[0]->[0], 'class',
+        'Observation sent to configured class observer first' );
+    is( $observations[0]->[2], 'fetch',
+        'Class observer sent the correct fetch action' );
+
+    is( $observations[1]->[0], 'sub',
+        'Observation sent to configured subroutine observer second' );
+    is( $observations[1]->[2], 'fetch',
+        'Subroutine observer sent the correct fetch action' );
+}
+
+{
+    $handle->{mock_add_resultset} = [ \@result_fields, \@result_data ];
+    my $wf = $factory->fetch_workflow( 'Ticket', 1 );
+    SomeObserver->clear_observations;
+    $wf->context->param({
+        subject => 'subject',
+        description => 'description',
+        creator => 'creator',
+        type => 'type'
+                        }
+        );
+    $wf->execute_action( 'TIX_NEW' );
+    my @observations = SomeObserver->get_observations;
+    is( scalar @observations, 8,
+        'Four observations sent on workflow execute to two observers' );
+
+    is( $observations[0]->[2], 'add history',
+        'History observation generated first to first observer' );
+    is( $observations[1]->[2], 'add history',
+        'History observation generated first to second observer' );
+
+    is( $observations[2]->[2], 'save',
+        'Save observation generated first to first observer' );
+    is( $observations[3]->[2], 'save',
+        'Save observation generated first to second observer' );
+
+    is( $observations[4]->[0], 'class',
+        'Observation sent to configured class observer first' );
+    is( $observations[4]->[2], 'execute',
+        'Class observer sent the correct execute action' );
+    is( $observations[4]->[3], 'INITIAL',
+        'Class observer sent the correct old state for execute' );
+
+    is( $observations[5]->[0], 'sub',
+        'Observation sent to configured subroutine observer second' );
+    is( $observations[5]->[2], 'execute',
+        'Subroutine observer sent the correct execute action' );
+    is( $observations[5]->[3], 'INITIAL',
+        'Subroutine observer sent the correct old state for execute' );
+
+    is( $observations[6]->[0], 'class',
+        'Observation sent to configured class observer first' );
+    is( $observations[6]->[2], 'state change',
+        'Class observer sent the correct state change action' );
+    is( $observations[6]->[3], 'INITIAL',
+        'Class observer sent the correct old state for state change' );
+
+    is( $observations[7]->[0], 'sub',
+        'Observation sent to configured subroutine observer second' );
+    is( $observations[7]->[2], 'state change',
+        'Subroutine observer sent the correct state change action' );
+    is( $observations[7]->[3], 'INITIAL',
+        'Subroutine observer sent the correct old state for state change' );
+}


### PR DESCRIPTION
# Description

This PR adds the ability to specify observers without changing the workflow definition. This enables customization of software without customizing the workflow file when the workflow is acceptable, but additional actions need to be triggered on state changes.)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
