### PR TITLE
Do not clobber $EVAL_ERROR by localizing before `eval`

### DIFF
--- a/lib/Workflow.pm
+++ b/lib/Workflow.pm
@@ -116,6 +116,7 @@ sub execute_action {
     my $old_state = $self->state;
     my ( $new_state, $action_return );
 
+    local $EVAL_ERROR = undef;
     eval {
         $action->validate($self);
         $self->log->debug("Action validated ok");
@@ -332,6 +333,8 @@ sub _get_next_state {
 sub _auto_execute_state {
     my ( $self, $wf_state ) = @_;
     my $action_name;
+
+    local $EVAL_ERROR = undef;
     eval { $action_name = $wf_state->get_autorun_action_name($self); };
     if ($EVAL_ERROR)
     {    # we found an error, possibly more than one or none action

--- a/lib/Workflow/Action/InputField.pm
+++ b/lib/Workflow/Action/InputField.pm
@@ -51,6 +51,7 @@ sub new {
     if ( my $source_class = $self->source_class ) {
         $log->debug("Possible values for '$name' from '$source_class'");
         unless ( $INCLUDED{$source_class} ) {
+            local $EVAL_ERROR = undef;
             eval "require $source_class";
             if ($EVAL_ERROR) {
                 configuration_error "Failed to include source class ",

--- a/lib/Workflow/Condition.pm
+++ b/lib/Workflow/Condition.pm
@@ -63,6 +63,8 @@ sub evaluate_condition {
             ->get_condition( $orig_condition, $wf->type );
         $log->debug( "Evaluating condition '$orig_condition'" );
         my $return_value;
+
+        local $EVAL_ERROR = undef;
         eval { $return_value = $condition->evaluate($wf) };
         if ($EVAL_ERROR) {
 

--- a/lib/Workflow/Condition/CheckReturn.pm
+++ b/lib/Workflow/Condition/CheckReturn.pm
@@ -63,11 +63,13 @@ sub evaluate {
     } elsif ( $arg =~ /^[a-zA-Z0-9_]+$/ ) {    # alpha-numeric, plus '_'
         $argval = $wf->context->param($arg);
     } else {
+        local $EVAL_ERROR = undef;
         $argval = eval $arg;
     }
 
     my $condval = $self->evaluate_condition( $wf, $cond );
 
+    local $EVAL_ERROR = undef;
     if ( eval "\$condval $op \$argval" ) {
         return 1;
     } else {

--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -40,6 +40,7 @@ sub evaluate {
     my $safe = Safe->new();
 
     $safe->share('$context');
+    local $EVAL_ERROR = undef;
     my $rv = $safe->reval($to_eval);
     if ($EVAL_ERROR) {
         condition_error

--- a/lib/Workflow/Config/Perl.pm
+++ b/lib/Workflow/Config/Perl.pm
@@ -84,6 +84,7 @@ sub _translate_perl {
     my $log = get_logger();
 
     no strict 'vars';
+    local $EVAL_ERROR = undef;
     my $data = eval $config;
     if ($EVAL_ERROR) {
         configuration_error "Cannot evaluate perl data structure ",

--- a/lib/Workflow/Config/XML.pm
+++ b/lib/Workflow/Config/XML.pm
@@ -55,6 +55,8 @@ sub parse {
         my $file_name = ( ref $item ) ? '[scalar ref]' : $item;
         $log->info("Will parse '$type' XML config file '$file_name'");
         my $this_config;
+
+        local $EVAL_ERROR = undef;
         eval { $this_config = $self->_translate_xml( $type, $item ); };
 
         # If processing multiple config files, this makes it much easier
@@ -81,6 +83,7 @@ sub parse {
 sub _translate_xml {
     my ( $self, $type, $config ) = @_;
     unless ($XML_REQUIRED) {
+        local $EVAL_ERROR = undef;
         eval { require XML::Simple };
         if ($EVAL_ERROR) {
             configuration_error "XML::Simple must be installed to parse ",

--- a/lib/Workflow/Factory.pm
+++ b/lib/Workflow/Factory.pm
@@ -315,6 +315,8 @@ sub _load_observers {
 
 sub _load_class {
     my ( $self, $class_to_load, $msg ) = @_;
+
+    local $EVAL_ERROR = undef;
     eval "require $class_to_load";
     if ($EVAL_ERROR) {
         my $full_msg = sprintf $msg, $class_to_load, $EVAL_ERROR;
@@ -450,6 +452,8 @@ sub save_workflow {
 
     my $wf_config = $self->_get_workflow_config( $wf->type );
     my $persister = $self->get_persister( $wf_config->{persister} );
+
+    local $EVAL_ERROR = undef;
     eval {
         $persister->update_workflow($wf);
         $self->log->info( "Workflow '", $wf->id, "' updated ok" );
@@ -538,6 +542,8 @@ sub _add_action_config {
             }
             $self->log->debug(
                 "Trying to include action class '$action_class'...");
+
+            local $EVAL_ERROR = undef;
             eval "require $action_class";
             if ($EVAL_ERROR) {
                 my $msg = $EVAL_ERROR;
@@ -599,6 +605,8 @@ sub _add_persister_config {
         }
         $self->log->debug(
             "Trying to include persister class '$persister_class'...");
+
+        local $EVAL_ERROR = undef;
         eval "require $persister_class";
         if ($EVAL_ERROR) {
             configuration_error "Cannot include persister class ",
@@ -607,6 +615,8 @@ sub _add_persister_config {
         $self->log->debug(
             "Included persister '$name' class '$persister_class' ",
             "ok; now try to instantiate persister..." );
+
+        # $EVAL_ERROR already localized above
         my $persister = eval { $persister_class->new($persister_config) };
         if ($EVAL_ERROR) {
             configuration_error "Failed to create instance of persister ",
@@ -678,6 +688,8 @@ sub _add_condition_config {
             }
             $self->log->debug(
                 "Trying to include condition class '$condition_class'");
+
+            local $EVAL_ERROR = undef;
             eval "require $condition_class";
             if ($EVAL_ERROR) {
                 configuration_error "Cannot include condition class ",
@@ -686,6 +698,8 @@ sub _add_condition_config {
             $self->log->debug(
                 "Included condition '$name' class '$condition_class' ",
                 "ok; now try to instantiate condition..." );
+
+            # $EVAL_ERROR already localized above
             my $condition = eval { $condition_class->new($condition_config) };
             if ($EVAL_ERROR) {
                 configuration_error
@@ -764,6 +778,8 @@ sub _add_validator_config {
             }
             $self->log->debug(
                 "Trying to include validator class '$validator_class'");
+
+            local $EVAL_ERROR = undef;
             eval "require $validator_class";
             if ($EVAL_ERROR) {
                 workflow_error
@@ -773,6 +789,8 @@ sub _add_validator_config {
                 "Included validator '$name' class '$validator_class' ",
                 " ok; now try to instantiate validator..."
                 );
+
+            # $EVAL_ERROR already localized above
             my $validator = eval { $validator_class->new($validator_config) };
             if ($EVAL_ERROR) {
                 workflow_error "Cannot create validator '$name': $EVAL_ERROR";

--- a/lib/Workflow/Persister.pm
+++ b/lib/Workflow/Persister.pm
@@ -54,6 +54,8 @@ sub assign_generators {
 sub init_random_generators {
     my ( $self, $params ) = @_;
     my $length = $params->{id_length} || DEFAULT_ID_LENGTH;
+
+    local $EVAL_ERROR = undef;
     eval { require Workflow::Persister::RandomId };
     if (my $msg = $EVAL_ERROR) {
         $msg =~ s/\\n/ /g;
@@ -67,6 +69,7 @@ sub init_random_generators {
 sub init_uuid_generators {
     my ( $self, $params ) = @_;
 
+    local $EVAL_ERROR = undef;
     eval { require Workflow::Persister::UUID };
     if (my $msg = $EVAL_ERROR) {
         $msg =~ s/\\n/ /g;

--- a/lib/Workflow/Persister/DBI.pm
+++ b/lib/Workflow/Persister/DBI.pm
@@ -73,6 +73,8 @@ sub create_handle {
             "key 'dsn' which maps to the first paramter ",
             "in the DBI 'connect()' call.";
     }
+
+    local $EVAL_ERROR = undef;
     my $dbh = eval {
                DBI->connect( $self->dsn, $self->user, $self->password )
             || croak "Cannot connect to database: $DBI::errstr";
@@ -217,6 +219,8 @@ sub create_workflow {
     }
 
     my ($sth);
+
+    local $EVAL_ERROR = undef;
     eval {
         $sth = $dbh->prepare($sql);
         $sth->execute(@values);
@@ -253,6 +257,8 @@ sub fetch_workflow {
     }
 
     my ($sth);
+
+    local $EVAL_ERROR = undef;
     eval {
         $sth = $self->handle->prepare($sql);
         $sth->execute($wf_id);
@@ -287,6 +293,8 @@ sub update_workflow {
     }
 
     my ($sth);
+
+    local $EVAL_ERROR = undef;
     eval {
         $sth = $self->handle->prepare($sql);
         $sth->execute( $wf->state, $update_date, $wf->id );
@@ -326,6 +334,8 @@ sub create_history {
         }
 
         my ($sth);
+
+        local $EVAL_ERROR = undef;
         eval {
             $sth = $dbh->prepare($sql);
             $sth->execute(@values);
@@ -364,6 +374,8 @@ sub fetch_history {
     }
 
     my ($sth);
+
+    local $EVAL_ERROR = undef;
     eval {
         $sth = $self->handle->prepare($sql);
         $sth->execute( $wf->id );
@@ -397,6 +409,7 @@ sub fetch_history {
 sub commit_transaction {
     my ( $self, $wf ) = @_;
     if ( not $self->autocommit() ) {
+        local $EVAL_ERROR = undef;
         eval { $self->handle->commit(); };
         if ($EVAL_ERROR) {
             $self->log->error("Caught error committing transaction: $EVAL_ERROR");
@@ -408,6 +421,7 @@ sub commit_transaction {
 sub rollback_transaction {
     my ( $self, $wf ) = @_;
     if ( not $self->autocommit() ) {
+        local $EVAL_ERROR = undef;
         eval { $self->handle->rollback(); };
         if ($EVAL_ERROR) {
             $self->log->error("Caught error rolling back transaction: $EVAL_ERROR");

--- a/lib/Workflow/Persister/DBI/ExtraData.pm
+++ b/lib/Workflow/Persister/DBI/ExtraData.pm
@@ -65,6 +65,7 @@ sub fetch_extra_workflow_data {
     $self->log->debug( "Bind parameters: ", $wf->id );
 
     my ($sth);
+    local $EVAL_ERROR = undef;
     eval {
         $sth = $self->handle->prepare($sql);
         $sth->execute( $wf->id );

--- a/lib/Workflow/Persister/DBI/SequenceId.pm
+++ b/lib/Workflow/Persister/DBI/SequenceId.pm
@@ -27,6 +27,8 @@ sub pre_fetch_id {
     my $full_select = sprintf $self->sequence_select, $self->sequence_name;
     $self->log->debug("SQL to fetch sequence: ", $full_select);
     my ($row);
+
+    local $EVAL_ERROR = undef;
     eval {
         my $sth = $dbh->prepare($full_select);
         $sth->execute;

--- a/lib/Workflow/Persister/File.pm
+++ b/lib/Workflow/Persister/File.pm
@@ -61,6 +61,8 @@ sub fetch_workflow {
         persist_error "No workflow with ID '$wf_id' is available";
     }
     $self->log->debug("File exists, reconstituting workflow");
+
+    local $EVAL_ERROR = undef;
     my $wf_info = eval { $self->constitute_object($full_path) };
     if ($EVAL_ERROR) {
         persist_error "Cannot reconstitute data from file for ",
@@ -149,6 +151,7 @@ sub constitute_object {
     my $content = slurp($object_path);
 
     no strict;
+    local $EVAL_ERROR = undef;
     my $object = eval $content;
     croak $EVAL_ERROR if ($EVAL_ERROR);
     return $object;

--- a/lib/Workflow/State.pm
+++ b/lib/Workflow/State.pm
@@ -78,6 +78,7 @@ sub get_available_action_names {
 
 sub is_action_available {
     my ( $self, $wf, $action_name ) = @_;
+    local $EVAL_ERROR = undef;
     eval { $self->evaluate_action( $wf, $action_name ) };
 
     # Everything is fine
@@ -108,6 +109,7 @@ sub evaluate_action {
         my $condition_name = $condition->name;
 
         my $rv;
+        local $EVAL_ERROR = undef;
         eval {
             $rv = Workflow::Condition->evaluate_condition($wf, $condition_name);
         };

--- a/lib/Workflow/Validator/MatchesDateFormat.pm
+++ b/lib/Workflow/Validator/MatchesDateFormat.pm
@@ -35,6 +35,7 @@ sub validate {
     return unless ($date_string);
 
     # already converted!
+    local $EVAL_ERROR = undef;
     if ( ref $date_string and eval { $date_string->isa('DateTime'); } ) {
         return;
     }


### PR DESCRIPTION
# Description

Protect the caller's value of `$@` by localizing it before calling `eval`.

Please note that only a PR for 1.x is required as 2.x (master) already has the required localizations in place.

Fixes/addresses (If applicable) # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-workflow/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
