### PR TITLE
Prevent clobbering of $@ by the Safe module

### DIFF
--- a/lib/Workflow/Condition/Evaluate.pm
+++ b/lib/Workflow/Condition/Evaluate.pm
@@ -39,6 +39,7 @@ sub evaluate {
     my $safe = Safe->new();
 
     $safe->share('$context');
+    local $@;
     my $rv = $safe->reval($to_eval);
 
     $self->log->debug( "Safe eval ran ok, returned: '",


### PR DESCRIPTION
The safe eval from the Safe module *also* clobbers $@.
